### PR TITLE
Use extForeignKey for value in controls dialog

### DIFF
--- a/src/nextapp/components/controls/rate-limiting.tsx
+++ b/src/nextapp/components/controls/rate-limiting.tsx
@@ -124,8 +124,8 @@ const RateLimiting: React.FC<RateLimitingProps> = ({
       title="Rate Limiting"
     >
       <ControlTypeSelect
-        serviceId={data?.service?.id}
-        routeId={data?.route?.id}
+        serviceId={data?.service?.extForeignKey}
+        routeId={data?.route?.extForeignKey}
       />
       <HStack spacing={4} mb={4}>
         <FormControl id="second">

--- a/src/nextapp/pages/manager/consumers/[id].tsx
+++ b/src/nextapp/pages/manager/consumers/[id].tsx
@@ -171,10 +171,12 @@ const query = gql`
         service {
           id
           name
+          extForeignKey
         }
         route {
           id
           name
+          extForeignKey
         }
       }
       tags

--- a/src/test/mock-server/server.js
+++ b/src/test/mock-server/server.js
@@ -316,6 +316,7 @@ const server = mockServer(schemaWithMocks, {
     name: casual.route,
     namespace: casual.namespace,
     kongRouteId: casual.uuid,
+    extForeignKey: casual.uuid,
     methods: JSON.stringify([
       casual.random_element(['GET', 'POST', 'PUT', 'DELETE']),
     ]),


### PR DESCRIPTION
Fixes #167 

Uses `extForeignKey` to set the selected dropdown value in the plugin edit dialog.