### PR TITLE
Fix to allow credential generation even after other namespace users are not found in the database but are available in Keycloak

### DIFF
--- a/src/lists/extensions/Namespace.ts
+++ b/src/lists/extensions/Namespace.ts
@@ -219,19 +219,21 @@ module.exports = {
                 });
                 permissions = updatedPermissions;
               }
-              const listOfUsers: Array<any> = [];
+              const listOfUsers = [];
               for (const perm of permissions) {
                 if (perm.granted) {
                   const user = await lookupUserByUsername(
                     noauthContext,
                     perm.requesterName
                   );
-                  listOfUsers.push({
-                    id: user[0].id,
-                    name: user[0].name,
-                    username: user[0].username,
-                    email: user[0].email,
-                  });
+                  if (user.length > 0) {
+                    listOfUsers.push({
+                      id: user[0].id,
+                      name: user[0].name,
+                      username: user[0].username,
+                      email: user[0].email,
+                    });
+                  }
                 }
               }
               return listOfUsers;

--- a/src/services/keystone/index.ts
+++ b/src/services/keystone/index.ts
@@ -44,6 +44,7 @@ export {
   updateUserLegalAccept,
   LegalAgreed,
   lookupUserByUsername,
+  lookupUsersByUsernames,
   lookupUser,
   lookupUsersByNamespace,
 } from './user';

--- a/src/services/keystone/user.ts
+++ b/src/services/keystone/user.ts
@@ -83,7 +83,26 @@ export async function lookupUserByUsername(
     variables: { username: username },
   });
   logger.debug('Query [lookupUserByUsername] result %j', result);
-  //assert.strictEqual(result.data.allUsers.length, 1, 'UserNotFound');
+  assert.strictEqual(result.data.allUsers.length, 1, 'UserNotFound');
+  return result.data.allUsers;
+}
+
+export async function lookupUsersByUsernames(
+  context: any,
+  usernameList: string[]
+): Promise<[User]> {
+  const result = await context.executeGraphQL({
+    query: `query GetUsersWithUsernames($usernames: [String!]!) {
+                    allUsers(where: {username_in: $usernames}) {
+                        id
+                        name
+                        username
+                        email
+                    }
+                }`,
+    variables: { usernames: usernameList },
+  });
+  logger.debug('Query [lookupUsersByUsernames] result %j', result);
   return result.data.allUsers;
 }
 

--- a/src/services/keystone/user.ts
+++ b/src/services/keystone/user.ts
@@ -83,7 +83,7 @@ export async function lookupUserByUsername(
     variables: { username: username },
   });
   logger.debug('Query [lookupUserByUsername] result %j', result);
-  assert.strictEqual(result.data.allUsers.length, 1, 'UserNotFound');
+  //assert.strictEqual(result.data.allUsers.length, 1, 'UserNotFound');
   return result.data.allUsers;
 }
 


### PR DESCRIPTION
Fixes #188 

There is a gap in the user data in keycloak and portal database. We usually fetch namespace user list to send notifications after generation of credentials. Due to non availability of user details in the database, the fetch user function failed and due to which it generated an error during credential generation.