### PR TITLE
Quick fix for request access button and login styles

### DIFF
--- a/src/nextapp/components/access-request-form/access-request-dialog.tsx
+++ b/src/nextapp/components/access-request-form/access-request-dialog.tsx
@@ -61,9 +61,6 @@ const AccessRequestDialog: React.FC<AccessRequestDialogProps> = ({
   const submitButtonText = isAutoApproved
     ? 'Request Access & Continue'
     : 'Request Access';
-  const requestAccessButtonText = auth.user
-    ? 'Request Access'
-    : 'Sign in to request access';
   const [accessRequestId, setAccessRequestId] = React.useState<string>('');
 
   // Events
@@ -147,15 +144,22 @@ const AccessRequestDialog: React.FC<AccessRequestDialogProps> = ({
 
   return (
     <>
-      <Button
-        colorScheme="green"
-        disabled={!auth.user ?? disabled}
-        variant="solid"
-        onClick={onOpen}
-        data-testid="request-access-button"
-      >
-        {requestAccessButtonText}
-      </Button>
+      {auth.user && (
+        <Button
+          colorScheme="green"
+          disabled={disabled}
+          variant="solid"
+          onClick={onOpen}
+          data-testid="request-access-button"
+        >
+          Request Access
+        </Button>
+      )}
+      {!auth.user && (
+        <Button as="a" href="/admin/signin">
+          Request Access
+        </Button>
+      )}
       <Modal
         isOpen={open || isOpen}
         onClose={onClose}

--- a/src/nextapp/components/auth-action/auth-action.tsx
+++ b/src/nextapp/components/auth-action/auth-action.tsx
@@ -31,7 +31,7 @@ const Signin: React.FC<AuthActionProps> = ({ site }) => {
     return (
       <Button
         as="a"
-        variant="header"
+        variant="secondary"
         href="/admin/signin"
         data-testid="login-btn"
       >


### PR DESCRIPTION
Quick fix that switches the API Directory `Request Access` button to always be in an enabled state, but redirect to login if the user isn't signed in. Also contains a style change for the `Login` button to follow BC Design Guidelines.