### PR TITLE
Release 1.2 Hotfix Consumer Filters for acl-only flows

### DIFF
--- a/src/auth/auth-oauth2-proxy.js
+++ b/src/auth/auth-oauth2-proxy.js
@@ -391,20 +391,28 @@ class Oauth2ProxyAuthStrategy {
         saved.providerUsername != providerUsername
       ) {
         logger.info(
-          'register_user - updating name (%s), email (%s), providerUserGuid (%s), providerUsername (%s) for %s',
+          'register_user - updating name (%s), email (%s), provider (%s), providerUserGuid (%s), providerUsername (%s) for %s',
           name,
           email,
+          identityProvider,
           providerUserGuid,
           providerUsername,
           username
         );
         const { data, errors } = await this.keystone.executeGraphQL({
           context: this.keystone.createContext({ skipAccessControl: true }),
-          query: `mutation ($name: String, $email: String, $providerUsername: String, $userId: ID!) {
-                          updateUser(id: $userId, data: {name: $name, email: $email, providerUsername: $providerUsername }) {
+          query: `mutation ($name: String, $email: String, $identityProvider: String, $providerUserGuid: String, $providerUsername: String, $userId: ID!) {
+                          updateUser(id: $userId, data: {name: $name, email: $email, provider: $identityProvider, providerUserGuid: $providerUserGuid, providerUsername: $providerUsername }) {
                               id
                       } }`,
-          variables: { name, email, providerUsername, userId },
+          variables: {
+            name,
+            email,
+            identityProvider,
+            providerUserGuid,
+            providerUsername,
+            userId,
+          },
         });
         if (errors) {
           logger.error(

--- a/src/authz/graphql-whitelist/httplocalhost4180managerconsumers-0c6fa7.gql
+++ b/src/authz/graphql-whitelist/httplocalhost4180managerconsumers-0c6fa7.gql
@@ -1,0 +1,15 @@
+
+  query GetConsumers($filter: ConsumerQueryFilterInput) {
+    allConsumerGroupLabels
+
+    getFilteredNamespaceConsumers(filter: $filter) {
+      id
+      consumerType
+      username
+      labels {
+        labelGroup
+        values
+      }
+      lastUpdated
+    }
+  }

--- a/src/authz/graphql-whitelist/httplocalhost4180managerconsumers-d3af35.gql
+++ b/src/authz/graphql-whitelist/httplocalhost4180managerconsumers-d3af35.gql
@@ -1,0 +1,33 @@
+
+  query GetAccessRequests {
+    allAccessRequestsByNamespace(
+      where: { isIssued: true, isComplete_not: true }
+    ) {
+      id
+      name
+      additionalDetails
+      communication
+      createdAt
+      requestor {
+        name
+        providerUsername
+        email
+      }
+      application {
+        name
+      }
+      productEnvironment {
+        id
+        name
+        additionalDetailsToRequest
+        product {
+          name
+        }
+      }
+      serviceAccess {
+        consumer {
+          id
+        }
+      }
+    }
+  }

--- a/src/authz/graphql-whitelist/httplocalhost4180managerconsumers-ffe211.gql
+++ b/src/authz/graphql-whitelist/httplocalhost4180managerconsumers-ffe211.gql
@@ -1,0 +1,36 @@
+
+  query GetConsumers($filter: ConsumerQueryFilterInput) {
+    allConsumerGroupLabels
+    getFilteredNamespaceConsumers(filter: $filter) {
+      id
+      consumerType
+      username
+      labels {
+        labelGroup
+        values
+      }
+      lastUpdated
+    }
+
+    allAccessRequestsByNamespace(
+      where: { isIssued: true, isComplete_not: true }
+    ) {
+      id
+      name
+      additionalDetails
+      communication
+      createdAt
+      requestor {
+        name
+        providerUsername
+        email
+      }
+      application {
+        name
+      }
+      productEnvironment {
+        name
+        additionalDetailsToRequest
+      }
+    }
+  }

--- a/src/nextapp/components/access-request/access-request-dialog.tsx
+++ b/src/nextapp/components/access-request/access-request-dialog.tsx
@@ -88,7 +88,7 @@ const AccessRequestDialog: React.FC<AccessRequestDialogProps> = ({
       });
       toast({
         status: 'warning',
-        title: 'Access Request Rejected',
+        title: 'Access request rejected',
         description: 'The consumer will not be able to access your API',
         duration: null,
         isClosable: true,
@@ -96,8 +96,8 @@ const AccessRequestDialog: React.FC<AccessRequestDialogProps> = ({
     } catch (err) {
       toast({
         status: 'error',
-        title: 'Access Rejection Failed',
-        description: Array.isArray(err) ? err[0].message : err?.message,
+        title: 'Access rejection failed',
+        description: err,
       });
     }
   };
@@ -133,7 +133,7 @@ const AccessRequestDialog: React.FC<AccessRequestDialogProps> = ({
       client.invalidateQueries(['allConsumers']);
       toast({
         status: 'success',
-        title: 'Access Request Approved',
+        title: 'Access request approved',
         description: 'The consumer can now access your API',
         duration: null,
         isClosable: true,
@@ -141,8 +141,8 @@ const AccessRequestDialog: React.FC<AccessRequestDialogProps> = ({
     } catch (err) {
       toast({
         status: 'error',
-        title: 'Access Approval Failed',
-        description: Array.isArray(err) ? err[0].message : err?.message,
+        title: 'Access approval failed',
+        description: err,
       });
     }
   };

--- a/src/nextapp/components/access-request/access-requests-list.tsx
+++ b/src/nextapp/components/access-request/access-requests-list.tsx
@@ -40,7 +40,9 @@ export default AccessRequestsList;
 
 const query = gql`
   query GetAccessRequests {
-    allAccessRequestsByNamespace(where: { isComplete_not: true }) {
+    allAccessRequestsByNamespace(
+      where: { isIssued: true, isComplete_not: true }
+    ) {
       id
       name
       additionalDetails

--- a/src/nextapp/components/access-request/edit-dialog.tsx
+++ b/src/nextapp/components/access-request/edit-dialog.tsx
@@ -156,7 +156,7 @@ const ConsumerEditDialog: React.FC<ConsumerEditDialogProps> = ({
     } catch (err) {
       toast({
         title: 'Request save failed',
-        description: Array.isArray(err) ? err[0].message : err?.message,
+        description: err,
         status: 'error',
       });
     }

--- a/src/nextapp/components/access-request/grant-access-dialog.tsx
+++ b/src/nextapp/components/access-request/grant-access-dialog.tsx
@@ -121,7 +121,7 @@ const GrantAccessDialog: React.FC<GrantAccessDialogProps> = ({
     } catch (err) {
       toast({
         title: 'Access grant failed',
-        description: Array.isArray(err) ? err[0].message : err?.message,
+        description: err,
         status: 'error',
       });
     }

--- a/src/nextapp/pages/manager/consumers/index.tsx
+++ b/src/nextapp/pages/manager/consumers/index.tsx
@@ -315,6 +315,7 @@ export default ConsumersPage;
 const query = gql`
   query GetConsumers($filter: ConsumerQueryFilterInput) {
     allConsumerGroupLabels
+
     getFilteredNamespaceConsumers(filter: $filter) {
       id
       consumerType
@@ -324,26 +325,6 @@ const query = gql`
         values
       }
       lastUpdated
-    }
-
-    allAccessRequestsByNamespace(where: { isComplete_not: true }) {
-      id
-      name
-      additionalDetails
-      communication
-      createdAt
-      requestor {
-        name
-        providerUsername
-        email
-      }
-      application {
-        name
-      }
-      productEnvironment {
-        name
-        additionalDetailsToRequest
-      }
     }
   }
 `;

--- a/src/services/workflow/consumer-filters.ts
+++ b/src/services/workflow/consumer-filters.ts
@@ -92,7 +92,10 @@ async function filterByProductAndEnvironment(
   );
 
   const aclBasedConsumerIds = await queryACLConsumerIds(context, filteredEnvs);
-  logger.debug('[filterByProductAndEnvironment] %j', aclBasedConsumerIds);
+  logger.debug(
+    '[filterByProductAndEnvironment] aclBasedConsumerIds=%j',
+    aclBasedConsumerIds
+  );
 
   // Now get Consumers from the ServiceAccess matching the envs
   const serviceAccessBasedIds = await queryServiceAccessConsumerIds(
@@ -100,7 +103,10 @@ async function filterByProductAndEnvironment(
     ns,
     filteredEnvs
   );
-  logger.debug('[filterByProductAndEnvironment] %j', serviceAccessBasedIds);
+  logger.debug(
+    '[filterByProductAndEnvironment] serviceAccessBasedIds=%j',
+    serviceAccessBasedIds
+  );
 
   return aclBasedConsumerIds.concat(serviceAccessBasedIds);
 }
@@ -115,7 +121,7 @@ async function queryACLConsumerIds(
   envs: Environment[]
 ): Promise<string[]> {
   const envAppIds = envs
-    .filter((e) => e.flow === 'kong-api-key-acl')
+    .filter((e) => e.flow === 'kong-api-key-acl' || e.flow === 'kong-acl-only')
     .map((e) => e.appId);
 
   if (envAppIds.length == 0) {


### PR DESCRIPTION
Fixes:
- access requests appearing when credentials not collected
- user identity provider properties not updating on login
- toast for grant access not showing error
- consumer filter not filtering for acl-only flow
