### PR TITLE
Feature/ns-to-gw-fix-scopes-form

### DIFF
--- a/src/nextapp/components/namespace-access/users-access.tsx
+++ b/src/nextapp/components/namespace-access/users-access.tsx
@@ -86,7 +86,7 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
           requesterEmail,
           scopes: groupedByRequester[r].map((d) => ({
             id: d.scope,
-            name: d.scopeName.replace(/Namespace/g, 'Gateway'),
+            name: d.scopeName,
           })),
           tickets: groupedByRequester[r].map((d) => d.id),
         };
@@ -265,7 +265,7 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
               <Wrap>
                 {d.scopes.map((s) => (
                   <WrapItem key={uid(s)}>
-                    <Tag variant="outline">{s.name}</Tag>
+                    <Tag variant="outline">{s.name.replace(/Namespace/g, 'Gateway')}</Tag>
                   </WrapItem>
                 ))}
               </Wrap>


### PR DESCRIPTION
I had introduced a bug where `Gateway` replaced `Namespace` not just the scopes labels in the Portal (e.g. `Gateway.View`, but the data sent in the API mutation.