### PR TITLE
replace Namespace with Gateway in org permission

### DIFF
--- a/src/nextapp/components/namespace-access/organization-groups-access.tsx
+++ b/src/nextapp/components/namespace-access/organization-groups-access.tsx
@@ -136,7 +136,7 @@ const OrganizationGroupsAccess: React.FC<OrganizationGroupsAccessProps> = ({
               <Wrap>
                 {d.scopes.map((t) => (
                   <WrapItem key={t}>
-                    <Tag variant="outline">{t}</Tag>
+                    <Tag variant="outline">{t.replace(/Namespace/g, 'Gateway')}</Tag>
                   </WrapItem>
                 ))}
               </Wrap>


### PR DESCRIPTION
Small fix to change `Namespace.View` to `Gateway.View` on 'Organization groups with access' tab, using the same approach as the other components in `src/nextapp/components/namespace-access`.