### PR TITLE
tweak style for gateway list item hover

### DIFF
--- a/src/nextapp/pages/manager/gateways/detail.tsx
+++ b/src/nextapp/pages/manager/gateways/detail.tsx
@@ -247,7 +247,7 @@ const NamespacesPage: React.FC = () => {
                   <PopoverArrow bgColor="#373d3f" />
                   <PopoverBody>
                     If you need to change the Organization or Business Unit for
-                    your Namespace, submit a request through the{' '}
+                    your Gateway, submit a request through the{' '}
                     <Link
                       href={global.helpLinks.helpChangeOrgUrl}
                       target="_blank"

--- a/src/nextapp/pages/manager/gateways/list.tsx
+++ b/src/nextapp/pages/manager/gateways/list.tsx
@@ -292,7 +292,15 @@ const MyGatewaysPage: React.FC = () => {
                     onClick={handleNamespaceChange(namespace)}
                     cursor="pointer"
                     transition="background-color 0.2s"
-                    _hover={{ backgroundColor: "#f0f0f0" }}
+                    _hover={{
+                      backgroundColor: "#EDEBE9",
+                      h2: {
+                        color: 'bc-blue',
+                        textDecor: 'underline',
+                      },
+
+                      cursor: 'pointer',
+                    }}
                   >
                     <Box>
                       <Flex alignItems="center">
@@ -302,15 +310,15 @@ const MyGatewaysPage: React.FC = () => {
                           mr={4}
                           boxSize={4}
                         />
-                        <Text
+                        <Heading
                           fontSize="md"
                           fontWeight="bold"
-                          color="bc-blue"
+                          lineHeight={6}
                           mr={2}
                           data-testid={`ns-list-activate-link-${namespace.name}`}
                         >
                           {namespace.displayName}
-                        </Text>
+                        </Heading>
                       </Flex>
                       <Text fontSize="md" pl="33px">
                         {namespace.name}


### PR DESCRIPTION
Follows up on Tim's comment on #1179 - https://github.com/bcgov/api-services-portal/pull/1179#pullrequestreview-2307883242
> I'm wondering if we're able to style the Gateway display name with an underline based on the state of the parent to better match the styling of cards in the Gateways manager:

![image](https://github.com/user-attachments/assets/c2a2aad5-dfa3-4e9e-9476-649037e08e25)

We think the hover background is rather dark but apparently that's the recommendation in the BC design tokens.

---
🚀 Feature branch deployment: https://api-services-portal-feature-click-gateway-item.apps.silver.devops.gov.bc.ca

---
🚀 Feature branch deployment: https://api-services-portal-feature-click-gateway-item.apps.silver.devops.gov.bc.ca