### PR TITLE
Feature/fix dataset selection

### DIFF
--- a/src/nextapp/components/products-list/dataset-input.tsx
+++ b/src/nextapp/components/products-list/dataset-input.tsx
@@ -76,6 +76,11 @@ const DatasetInput: React.FC<DatasetInputProps> = ({ dataset }) => {
 
   const isInvalid = search.length > 0 && !selected;
 
+  const titleCounts = (results || []).reduce((acc, d) => {
+    acc[d.title] = (acc[d.title] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
   return (
     <>
       <FormControl id="dataset" position="relative" isInvalid={isInvalid}>
@@ -158,7 +163,9 @@ const DatasetInput: React.FC<DatasetInputProps> = ({ dataset }) => {
                         },
                       })}
                     >
-                      <Text fontSize="md">{d.title}</Text>
+                      <Text fontSize="md">
+                        {d.title} {titleCounts[d.title] > 1 ? `(${d.name})` : ''}
+                      </Text>
                     </Box>
                   ))}
                 {isOpen && isSuccess && !results.length && (

--- a/src/nextapp/components/products-list/dataset-input.tsx
+++ b/src/nextapp/components/products-list/dataset-input.tsx
@@ -52,7 +52,9 @@ const DatasetInput: React.FC<DatasetInputProps> = ({ dataset }) => {
     [setSearch]
   );
   const handleBlur = () => {
-    if (search.trim()) {
+    if (selected) {
+      setSelected(selected);
+    } else if (search.trim()) {
       const result = data?.allDatasets.find((d) => {
         if (search.trim()) {
           return d.title.toLowerCase() === search.toLowerCase();


### PR DESCRIPTION
Fixes #1224 

- Adds the dataset name in parentheses after the dataset title only when there are duplicate titles
- Fixes the bug where the first duplicate always gets selected when clicking away from the input box or clicking Update

---
🚀 Feature branch deployment: https://api-services-portal-feature-fix-dataset-selection.apps.silver.devops.gov.bc.ca