### PR TITLE
throw error when error getting list of gateways

### DIFF
--- a/src/controllers/v1/NamespaceController.ts
+++ b/src/controllers/v1/NamespaceController.ts
@@ -14,6 +14,8 @@ import { WorkbookService } from '../../services/report/workbook.service';
 import { Namespace } from '@/services/keystone/types';
 import { Logger } from '../../logger';
 
+import { strict as assert } from 'assert';
+
 import { Readable } from 'stream';
 
 /**
@@ -81,6 +83,7 @@ export class NamespaceController extends Controller {
       query: list,
     });
     logger.debug('Result %j', result);
+    assert.strictEqual('errors' in result, false, 'Unable to process request');
     return result.data.allNamespaces.map((ns: Namespace) => ns.name);
   }
 }

--- a/src/controllers/v2/NamespaceController.ts
+++ b/src/controllers/v2/NamespaceController.ts
@@ -110,6 +110,7 @@ export class NamespaceController extends Controller {
       query: list,
     });
     logger.debug('Result %j', result);
+    assert.strictEqual('errors' in result, false, 'Unable to process request');
     return result.data.allNamespaces.map((ns: Namespace) => ns.name).sort();
   }
 

--- a/src/controllers/v3/GatewayController.ts
+++ b/src/controllers/v3/GatewayController.ts
@@ -111,11 +111,22 @@ export class NamespaceController extends Controller {
       query: list,
     });
     logger.debug('Result %j', result);
+    assert.strictEqual('errors' in result, false, 'Unable to process request');
+
     return result.data.allNamespaces
-      .map((ns: Namespace): Gateway => ({ gatewayId: ns.name, displayName: ns.displayName }))
+      .map(
+        (ns: Namespace): Gateway => ({
+          gatewayId: ns.name,
+          displayName: ns.displayName,
+        })
+      )
       .sort((a: Gateway, b: Gateway) => {
-        const displayNameComparison = a.displayName.localeCompare(b.displayName);
-        return displayNameComparison !== 0 ? displayNameComparison : a.gatewayId.localeCompare(b.gatewayId);
+        const displayNameComparison = a.displayName.localeCompare(
+          b.displayName
+        );
+        return displayNameComparison !== 0
+          ? displayNameComparison
+          : a.gatewayId.localeCompare(b.gatewayId);
       });
   }
 

--- a/src/services/checkStatus.ts
+++ b/src/services/checkStatus.ts
@@ -13,6 +13,7 @@ export async function checkStatus(res: any) {
       reason: 'unknown_error',
       description: '',
       status: `${res.status} ${res.statusText}`,
+      statusCode: res.status,
     };
     logger.error('Error - %d %s', res.status, res.statusText);
     const body = await res.text();

--- a/src/services/issuerMisconfigError.ts
+++ b/src/services/issuerMisconfigError.ts
@@ -2,6 +2,7 @@ export interface IssuerMisconfigDetail {
   reason: string;
   description: string;
   status: string;
+  statusCode: number;
 }
 
 export class IssuerMisconfigError extends Error {

--- a/src/services/uma2/token-service.ts
+++ b/src/services/uma2/token-service.ts
@@ -97,7 +97,9 @@ export class UMA2TokenService {
           return res.json();
         } else if (res.status == 403) {
           // users that have no resources will get a 403, so gracefully handle that as "access to no resources"
-          return [];
+          return new Promise((resolve) => {
+            resolve([]);
+          });
         } else {
           return checkStatus(res);
         }


### PR DESCRIPTION
- This PR adds some consistency with the responses for getting a list of gateways.  Instead of throwing a 500 error due to a null reference, it throws an assertion error when there is some kind of error getting the list of gateways.  Internal reference APS-3328.

---
🚀 Feature branch deployment: https://api-services-portal-feature-aps-3328-gateways-list.apps.silver.devops.gov.bc.ca