### PR TITLE
APS-4156 remove services from response

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ Use the following configuration to run the Portal locally (outside of Docker) ag
 1. Start the OAuth2 Proxy locally:
 
 ```sh
+# mac
 hostip=$(ifconfig en0 | awk '$1 == "inet" {print $2}')
+
+# WSL
+hostip=$(hostname -I | awk '{print $1}')
 
 docker run -ti --rm --name proxy --net=host \
   --add-host portal.localtest.me:$hostip \

--- a/e2e/cypress/tests/09-update-product-env/09-two-tiered-hidden.cy.ts
+++ b/e2e/cypress/tests/09-update-product-env/09-two-tiered-hidden.cy.ts
@@ -95,7 +95,7 @@ describe('Verify Two Tiered Hidden', () => {
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })
@@ -106,7 +106,7 @@ describe('Verify Two Tiered Hidden', () => {
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })
@@ -122,18 +122,18 @@ describe('Verify Two Tiered Hidden', () => {
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })
-
+  
   it('Verify that product is formatted correctly in your products page', () => {
     cy.visit(apiDir.path)
     apiDir.navigateToYourProduct()
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })

--- a/e2e/cypress/tests/15-aps-api/08-namespaces.cy.ts
+++ b/e2e/cypress/tests/15-aps-api/08-namespaces.cy.ts
@@ -237,7 +237,7 @@ describe('API Tests for invalid namespace name', () => {
                         cy.makeAPIRequest(namespaces.endPoint, 'POST').then((res:any) => {
                             expect(res.apiRes.status).to.be.equal(422)
                             cy.addToAstraScanIdList(res.astraRes.body.status)
-                            expect(res.apiRes.body.message).to.be.equal('Validation Failed')
+                            expect(res.apiRes.body.message).to.be.equal('Unable to create gateway')
                         })
                     })
                 })

--- a/e2e/cypress/tests/17-delete-application/04-delete-namespace-gwa.ts
+++ b/e2e/cypress/tests/17-delete-application/04-delete-namespace-gwa.ts
@@ -65,7 +65,7 @@ describe('Verify namespace delete using gwa command', () => {
             cy.executeCliCommand('gwa config set --gateway ' + namespace).then((response) => {
                 expect(response.stdout).to.contain("Config settings saved")
                 cy.executeCliCommand('gwa gateway destroy').then((response) => {
-                    expect(response.stderr).to.contain('Error: Validation Failed');
+                    expect(response.stderr).to.contain('Error: Unable to delete gateway');
                 });
             })
         })
@@ -73,7 +73,7 @@ describe('Verify namespace delete using gwa command', () => {
 
     it('Check validation if any consumer is associated with namespace for hard deleting the namespace', () => {
         cy.executeCliCommand('gwa gateway destroy --force').then((response) => {
-            expect(response.stderr).to.contain('Error: Validation Failed');
+            expect(response.stderr).to.contain('Error: Unable to delete gateway');
         });
     })
 

--- a/e2e/cypress/tests/19-api-v3/01-api-directory.ts
+++ b/e2e/cypress/tests/19-api-v3/01-api-directory.ts
@@ -138,7 +138,7 @@ describe('API Directory', () => {
               {
                 name: `my-product-on-${gateway.gatewayId}`,
                 environments: [
-                  { name: 'dev', active: true, flow: 'public', services: [] },
+                  { name: 'dev', active: true, flow: 'public' },
                 ],
               },
             ],

--- a/e2e/cypress/tests/19-api-v3/03-gateways.ts
+++ b/e2e/cypress/tests/19-api-v3/03-gateways.ts
@@ -184,8 +184,9 @@ describe('Gateways', () => {
       cy.callAPI('ds/api/v3/gateways', 'POST').then(
         ({ apiRes: { body, status } }: any) => {
           const match = {
-            message: 'Validation Failed',
-            details: {
+            code: 'validation_error',
+            message: 'Unable to create Gateway',
+            fields: {
               d0: {
                 message:
                   'Gateway ID must be between 5 and 15 lowercase alpha-numeric characters and start with a letter.',
@@ -206,8 +207,9 @@ describe('Gateways', () => {
       cy.callAPI('ds/api/v3/gateways', 'POST').then(
         ({ apiRes: { body, status } }: any) => {
           const match = {
-            message: 'Validation Failed',
-            details: {
+            code: 'validation_error',
+            message: 'Unable to create Gateway',
+            fields: {
               d0: {
                 message:
                   'Display name must be between 3 and 30 characters, starting with an alpha-numeric character, and can only use special characters "-()_ .\'/".',
@@ -228,8 +230,9 @@ describe('Gateways', () => {
       cy.callAPI('ds/api/v3/gateways', 'POST').then(
         ({ apiRes: { body, status } }: any) => {
           const match = {
-            message: 'Validation Failed',
-            details: {
+            code: 'validation_error',
+            message: 'Unable to create Gateway',
+            fields: {
               d0: {
                 message:
                   'Display name must be between 3 and 30 characters, starting with an alpha-numeric character, and can only use special characters "-()_ .\'/".',

--- a/local/kong/Dockerfile
+++ b/local/kong/Dockerfile
@@ -1,9 +1,9 @@
-ARG KONG_VERSION="3.9.0"
+ARG KONG_VERSION="3.9.1"
 FROM docker.io/kong:${KONG_VERSION}
 
 USER root
 
-RUN apt-get update && apt-get -y install unzip && apt-get clean
+RUN apt-get update && apt-get -y install unzip curl && apt-get clean
 
 RUN git clone https://github.com/bcgov/kong-oss-plugins.git \
   && cd kong-oss-plugins \
@@ -15,7 +15,7 @@ RUN git clone https://github.com/bcgov/kong-oss-plugins.git \
          (*)  luarocks build --deps-only kong-plugin-oidc-deps-k2-1.5.0-2.rockspec;; \
      esac) \
   && (cd plugins/oidc-consumer && luarocks make)
-
+ 
 RUN git clone -b kong3 https://github.com/bcgov/gwa-kong-endpoint.git \
   && (cd gwa-kong-endpoint && ./devBuild.sh)
 
@@ -27,11 +27,11 @@ RUN luarocks install kong-spec-expose \
  && luarocks install kong-upstream-jwt
 
 RUN git clone https://github.com/Kong/priority-updater.git \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=902 KONG_PRIORITY_NAME=rate-limiting /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=1010 KONG_PRIORITY_NAME=jwt-keycloak /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=770 KONG_PRIORITY_NAME=pre-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=200 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=201 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua)
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=902 KONG_PRIORITY_NAME=rate-limiting /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=1010 KONG_PRIORITY_NAME=jwt-keycloak /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=770 KONG_PRIORITY_NAME=pre-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=200 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=201 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua)
 
 USER kong
 

--- a/src/controllers/ioc/assert.ts
+++ b/src/controllers/ioc/assert.ts
@@ -14,6 +14,6 @@ export function assertEqual(
     fieldErrors[field] = {
       message,
     };
-    throw new ValidateError(fieldErrors, '');
+    throw new ValidateError(fieldErrors, 'Validation Failed');
   }
 }

--- a/src/controllers/v2/DirectoryController.ts
+++ b/src/controllers/v2/DirectoryController.ts
@@ -43,9 +43,41 @@ export class DirectoryController extends Controller {
     }
 
     return transform(
-      transformSetAnonymous(result.data.allDiscoverableProducts)
+      transformRemoveServices(
+        transformSetTwoTieredHidden(
+          transformSetAnonymous(result.data.allDiscoverableProducts)
+        )
+      )
     )[0];
   }
+}
+
+export function transformRemoveServices(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      removeKeys(env, ['services']);
+    });
+  });
+  return products;
+}
+
+export function transformSetTwoTieredHidden(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      env.services.forEach((svc) => {
+        svc.plugins?.forEach((plugin) => {
+          if (plugin.tags) {
+            // Tags come from GraphQL as JSON strings, need to parse them
+            const tags: string[] = JSON.parse(plugin.tags);
+            if (tags.includes('aps.two-tiered-hidden')) {
+              (env as any).twoTieredHidden = true;
+            }
+          }
+        });
+      });
+    });
+  });
+  return products;
 }
 
 export function transformSetAnonymous(products: Product[]) {

--- a/src/controllers/v2/NamespaceDirectoryController.ts
+++ b/src/controllers/v2/NamespaceDirectoryController.ts
@@ -10,7 +10,11 @@ import {
 } from 'tsoa';
 import { KeystoneService } from '../ioc/keystoneInjector';
 import { inject, injectable } from 'tsyringe';
-import { transform, transformSetAnonymous } from './DirectoryController';
+import {
+  transform,
+  transformSetAnonymous,
+  transformSetTwoTieredHidden,
+} from './DirectoryController';
 import { gql } from 'graphql-request';
 import { strict as assert } from 'assert';
 
@@ -55,7 +59,9 @@ export class NamespaceDirectoryController extends Controller {
     );
 
     return transform(
-      transformSetAnonymous(result.data.allProductsByNamespace)
+      transformSetTwoTieredHidden(
+        transformSetAnonymous(result.data.allProductsByNamespace)
+      )
     )[0];
   }
 

--- a/src/controllers/v3/DirectoryController.ts
+++ b/src/controllers/v3/DirectoryController.ts
@@ -43,9 +43,41 @@ export class DirectoryController extends Controller {
     }
 
     return transform(
-      transformSetAnonymous(result.data.allDiscoverableProducts)
+      transformRemoveServices(
+        transformSetTwoTieredHidden(
+          transformSetAnonymous(result.data.allDiscoverableProducts)
+        )
+      )
     )[0];
   }
+}
+
+export function transformRemoveServices(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      removeKeys(env, ['services']);
+    });
+  });
+  return products;
+}
+
+export function transformSetTwoTieredHidden(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      env.services.forEach((svc) => {
+        svc.plugins?.forEach((plugin) => {
+          if (plugin.tags) {
+            // Tags come from GraphQL as JSON strings, need to parse them
+            const tags: string[] = JSON.parse(plugin.tags);
+            if (tags.includes('aps.two-tiered-hidden')) {
+              (env as any).twoTieredHidden = true;
+            }
+          }
+        });
+      });
+    });
+  });
+  return products;
 }
 
 export function transformSetAnonymous(products: Product[]) {

--- a/src/controllers/v3/GatewayDirectoryController.ts
+++ b/src/controllers/v3/GatewayDirectoryController.ts
@@ -10,7 +10,11 @@ import {
 } from 'tsoa';
 import { KeystoneService } from '../ioc/keystoneInjector';
 import { inject, injectable } from 'tsyringe';
-import { transform, transformSetAnonymous } from './DirectoryController';
+import {
+  transform,
+  transformSetAnonymous,
+  transformSetTwoTieredHidden,
+} from './DirectoryController';
 import { gql } from 'graphql-request';
 import { strict as assert } from 'assert';
 
@@ -55,7 +59,9 @@ export class GatewayDirectoryController extends Controller {
     );
 
     return transform(
-      transformSetAnonymous(result.data.allProductsByNamespace)
+      transformSetTwoTieredHidden(
+        transformSetAnonymous(result.data.allProductsByNamespace)
+      )
     )[0];
   }
 

--- a/src/nextapp/components/api-product-item/api-product-item.tsx
+++ b/src/nextapp/components/api-product-item/api-product-item.tsx
@@ -18,6 +18,7 @@ import { Dataset, Environment, Product } from '@/shared/types/query.types';
 
 export interface ApiEnvironment extends Environment {
   anonymous: boolean;
+  twoTieredHidden?: boolean;
 }
 
 export interface ApiProduct extends Product {
@@ -45,11 +46,7 @@ const ApiProductItem: React.FC<ApiProductItemProps> = ({
   );
   const isTiered = data.environments.some((e) => e.anonymous);
 
-  const isTieredHidden = data.environments.some((e) =>
-    e.services.some((s) =>
-      s.plugins.some((p) => p.tags.includes('aps.two-tiered-hidden'))
-    )
-  );
+  const isTieredHidden = data.environments.some((e) => e.twoTieredHidden);
 
   return (
     <>
@@ -59,11 +56,11 @@ const ApiProductItem: React.FC<ApiProductItemProps> = ({
             <Flex align="center" mb={2}>
               <Flex align="center" width={8}>
                 <Icon
-                  as={isPublic || isTiered ? RiEarthFill : FaLock}
+                  as={isPublic || isTiered && !isTieredHidden ? RiEarthFill : FaLock}
                   color="bc-blue"
                   boxSize="5"
                   data-testid={`product-icon-${kebabCase(data.name)}-${
-                    isPublic || isTiered ? 'RiEarthFill' : 'FaLock'
+                    isPublic || isTiered && !isTieredHidden ? 'RiEarthFill' : 'FaLock'
                   }`}
                 />
               </Flex>


### PR DESCRIPTION
## Summary

This PR sanitizes the Directory API response by removing the `services` payload and extracts the `twoTieredHidden` flag from plugin tags before services are removed. The UI is updated to use the extracted flag instead of accessing services directly.

The behaviour for two-tiered-hidden products is changed to show a lock icon instead of an earth (implying public), thereby _actually_ hiding two-tiered access. I couldn't find any tickets documenting the initial request or requirements from LOC, but noone is currently using this feature and I feel this is a more logical approach for potential future users.

## Changes

### API Controllers
- **Remove services from directory API responses** to reduce payload size
- **Extract `twoTieredHidden` flag** from plugin tags (`aps.two-tiered-hidden`) before removing services
- Apply changes to:
  - v2 and v3 Directory and GatewayDirectory/NamespaceDirectory controllers
  - v1 not updated: no longer available

### Frontend
- Update `api-product-item` component to use `twoTieredHidden` property instead of accessing services
- Show lock icon (FaLock) for two-tiered-hidden products instead of public icon (RiEarthFill)

## Other Updates
- Local Kong version bump (3.9.0 → 3.9.1) and added curl to Dockerfile (fix build issue)
- README: Added WSL hostip command for OAuth2 proxy setup
- Updated e2e tests to expect lock icon for two-tiered-hidden products



---
🚀 Feature branch deployment: https://api-services-portal-feature-APS-4156-remove-services-from-response.apps.silver.devops.gov.bc.ca

---
🚀 Feature branch deployment: https://api-services-portal-feature-APS-4156-remove-services-from-response.apps.silver.devops.gov.bc.ca