### PR TITLE
APS-4156 remove services from directory response

### DIFF
--- a/.github/workflows/ci-feat-sonar.yaml
+++ b/.github/workflows/ci-feat-sonar.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '22'
 
       - name: Run Tests
         run: |
@@ -44,14 +44,14 @@ jobs:
           docker compose down
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v6
         with:
           args: >
-            -Dsonar.organization=bcgov-oss
-            -Dsonar.projectKey=aps-portal
-            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.projectKey=bcgov_api-services-portal
             -Dsonar.sources=src/auth,src/authz,src/batch,src/services
             -Dsonar.javascript.lcov.reportPaths=./src/__coverage__/lcov.info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/ci-feat-sonar.yaml
+++ b/.github/workflows/ci-feat-sonar.yaml
@@ -49,13 +49,6 @@ jobs:
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarqube-scan-action@master
-        with:
-          args: >
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.projectKey=bcgov_api-services-portal
-            -Dsonar.sources=src/auth,src/authz,src/batch,src/services
-            -Dsonar.javascript.lcov.reportPaths=./src/__coverage__/lcov.info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/ci-feat-sonar.yaml
+++ b/.github/workflows/ci-feat-sonar.yaml
@@ -36,7 +36,7 @@ jobs:
 
           cd src
 
-          npm i
+          npm i --legacy-peer-deps
           npm run intg-build
           npm test
 

--- a/.github/workflows/ci-feat-sonar.yaml
+++ b/.github/workflows/ci-feat-sonar.yaml
@@ -19,6 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install deps
+        run: |
+          sudo apt update
+
       - uses: actions/setup-node@v2
         with:
           node-version: '22'
@@ -44,7 +48,7 @@ jobs:
           docker compose down
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@master
         with:
           args: >
             -Dsonar.organization=bcgov-sonarcloud

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ Use the following configuration to run the Portal locally (outside of Docker) ag
 1. Start the OAuth2 Proxy locally:
 
 ```sh
+# mac
 hostip=$(ifconfig en0 | awk '$1 == "inet" {print $2}')
+
+# WSL
+hostip=$(hostname -I | awk '{print $1}')
 
 docker run -ti --rm --name proxy --net=host \
   --add-host portal.localtest.me:$hostip \

--- a/e2e/cypress/tests/09-update-product-env/09-two-tiered-hidden.cy.ts
+++ b/e2e/cypress/tests/09-update-product-env/09-two-tiered-hidden.cy.ts
@@ -95,7 +95,7 @@ describe('Verify Two Tiered Hidden', () => {
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })
@@ -106,7 +106,7 @@ describe('Verify Two Tiered Hidden', () => {
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })
@@ -122,18 +122,18 @@ describe('Verify Two Tiered Hidden', () => {
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })
-
+  
   it('Verify that product is formatted correctly in your products page', () => {
     cy.visit(apiDir.path)
     apiDir.navigateToYourProduct()
     cy.get('@apiowner').then(({ twoTieredHidden }: any) => {
       let product = twoTieredHidden.product
       apiDir.selectProduct(product.serviceName)
-      apiDir.checkProductIcon(product.name, 'RiEarthFill')
+      apiDir.checkProductIcon(product.name, 'FaLock')
       apiDir.checkTwoTieredHiddenButton()
     })
   })

--- a/e2e/cypress/tests/15-aps-api/08-namespaces.cy.ts
+++ b/e2e/cypress/tests/15-aps-api/08-namespaces.cy.ts
@@ -237,7 +237,7 @@ describe('API Tests for invalid namespace name', () => {
                         cy.makeAPIRequest(namespaces.endPoint, 'POST').then((res:any) => {
                             expect(res.apiRes.status).to.be.equal(422)
                             cy.addToAstraScanIdList(res.astraRes.body.status)
-                            expect(res.apiRes.body.message).to.be.equal('Validation Failed')
+                            expect(res.apiRes.body.message).to.be.equal('Unable to create gateway')
                         })
                     })
                 })

--- a/e2e/cypress/tests/17-delete-application/04-delete-namespace-gwa.ts
+++ b/e2e/cypress/tests/17-delete-application/04-delete-namespace-gwa.ts
@@ -65,7 +65,7 @@ describe('Verify namespace delete using gwa command', () => {
             cy.executeCliCommand('gwa config set --gateway ' + namespace).then((response) => {
                 expect(response.stdout).to.contain("Config settings saved")
                 cy.executeCliCommand('gwa gateway destroy').then((response) => {
-                    expect(response.stderr).to.contain('Error: Validation Failed');
+                    expect(response.stderr).to.contain('Error: Unable to delete gateway');
                 });
             })
         })
@@ -73,7 +73,7 @@ describe('Verify namespace delete using gwa command', () => {
 
     it('Check validation if any consumer is associated with namespace for hard deleting the namespace', () => {
         cy.executeCliCommand('gwa gateway destroy --force').then((response) => {
-            expect(response.stderr).to.contain('Error: Validation Failed');
+            expect(response.stderr).to.contain('Error: Unable to delete gateway');
         });
     })
 

--- a/e2e/cypress/tests/19-api-v3/01-api-directory.ts
+++ b/e2e/cypress/tests/19-api-v3/01-api-directory.ts
@@ -138,7 +138,7 @@ describe('API Directory', () => {
               {
                 name: `my-product-on-${gateway.gatewayId}`,
                 environments: [
-                  { name: 'dev', active: true, flow: 'public', services: [] },
+                  { name: 'dev', active: true, flow: 'public' },
                 ],
               },
             ],

--- a/e2e/cypress/tests/19-api-v3/03-gateways.ts
+++ b/e2e/cypress/tests/19-api-v3/03-gateways.ts
@@ -184,8 +184,9 @@ describe('Gateways', () => {
       cy.callAPI('ds/api/v3/gateways', 'POST').then(
         ({ apiRes: { body, status } }: any) => {
           const match = {
-            message: 'Validation Failed',
-            details: {
+            code: 'validation_error',
+            message: 'Unable to create Gateway',
+            fields: {
               d0: {
                 message:
                   'Gateway ID must be between 5 and 15 lowercase alpha-numeric characters and start with a letter.',
@@ -206,8 +207,9 @@ describe('Gateways', () => {
       cy.callAPI('ds/api/v3/gateways', 'POST').then(
         ({ apiRes: { body, status } }: any) => {
           const match = {
-            message: 'Validation Failed',
-            details: {
+            code: 'validation_error',
+            message: 'Unable to create Gateway',
+            fields: {
               d0: {
                 message:
                   'Display name must be between 3 and 30 characters, starting with an alpha-numeric character, and can only use special characters "-()_ .\'/".',
@@ -228,8 +230,9 @@ describe('Gateways', () => {
       cy.callAPI('ds/api/v3/gateways', 'POST').then(
         ({ apiRes: { body, status } }: any) => {
           const match = {
-            message: 'Validation Failed',
-            details: {
+            code: 'validation_error',
+            message: 'Unable to create Gateway',
+            fields: {
               d0: {
                 message:
                   'Display name must be between 3 and 30 characters, starting with an alpha-numeric character, and can only use special characters "-()_ .\'/".',

--- a/local/kong/Dockerfile
+++ b/local/kong/Dockerfile
@@ -1,9 +1,9 @@
-ARG KONG_VERSION="3.9.0"
+ARG KONG_VERSION="3.9.1"
 FROM docker.io/kong:${KONG_VERSION}
 
 USER root
 
-RUN apt-get update && apt-get -y install unzip && apt-get clean
+RUN apt-get update && apt-get -y install unzip curl && apt-get clean
 
 RUN git clone https://github.com/bcgov/kong-oss-plugins.git \
   && cd kong-oss-plugins \
@@ -15,7 +15,7 @@ RUN git clone https://github.com/bcgov/kong-oss-plugins.git \
          (*)  luarocks build --deps-only kong-plugin-oidc-deps-k2-1.5.0-2.rockspec;; \
      esac) \
   && (cd plugins/oidc-consumer && luarocks make)
-
+ 
 RUN git clone -b kong3 https://github.com/bcgov/gwa-kong-endpoint.git \
   && (cd gwa-kong-endpoint && ./devBuild.sh)
 
@@ -27,11 +27,11 @@ RUN luarocks install kong-spec-expose \
  && luarocks install kong-upstream-jwt
 
 RUN git clone https://github.com/Kong/priority-updater.git \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=902 KONG_PRIORITY_NAME=rate-limiting /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=1010 KONG_PRIORITY_NAME=jwt-keycloak /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=770 KONG_PRIORITY_NAME=pre-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=200 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
- && (cd priority-updater/template/plugin && KONG_PRIORITY=201 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua)
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=902 KONG_PRIORITY_NAME=rate-limiting /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=1010 KONG_PRIORITY_NAME=jwt-keycloak /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=770 KONG_PRIORITY_NAME=pre-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=200 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua) \
+  && (cd priority-updater/template/plugin && KONG_PRIORITY=201 KONG_PRIORITY_NAME=post-function /usr/local/openresty/luajit/bin/luajit ../priority.lua)
 
 USER kong
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=bcgov-oss
+sonar.projectKey=aps-portal
+
+sonar.sources=src/auth,src/authz,src/batch,src/services
+sonar.javascript.lcov.reportPaths=./src/__coverage__/lcov.info
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.organization=bcgov-oss
-sonar.projectKey=aps-portal
+sonar.organization=bcgov-sonarcloud
+sonar.projectKey=bcgov_api-services-portal
 
 sonar.sources=src/auth,src/authz,src/batch,src/services
 sonar.javascript.lcov.reportPaths=./src/__coverage__/lcov.info

--- a/src/controllers/ioc/assert.ts
+++ b/src/controllers/ioc/assert.ts
@@ -14,6 +14,6 @@ export function assertEqual(
     fieldErrors[field] = {
       message,
     };
-    throw new ValidateError(fieldErrors, '');
+    throw new ValidateError(fieldErrors, 'Validation Failed');
   }
 }

--- a/src/controllers/v2/DirectoryController.ts
+++ b/src/controllers/v2/DirectoryController.ts
@@ -43,9 +43,41 @@ export class DirectoryController extends Controller {
     }
 
     return transform(
-      transformSetAnonymous(result.data.allDiscoverableProducts)
+      transformRemoveServices(
+        transformSetTwoTieredHidden(
+          transformSetAnonymous(result.data.allDiscoverableProducts)
+        )
+      )
     )[0];
   }
+}
+
+export function transformRemoveServices(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      removeKeys(env, ['services']);
+    });
+  });
+  return products;
+}
+
+export function transformSetTwoTieredHidden(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      env.services.forEach((svc) => {
+        svc.plugins?.forEach((plugin) => {
+          if (plugin.tags) {
+            // Tags come from GraphQL as JSON strings, need to parse them
+            const tags: string[] = JSON.parse(plugin.tags);
+            if (tags.includes('aps.two-tiered-hidden')) {
+              (env as any).twoTieredHidden = true;
+            }
+          }
+        });
+      });
+    });
+  });
+  return products;
 }
 
 export function transformSetAnonymous(products: Product[]) {

--- a/src/controllers/v2/NamespaceDirectoryController.ts
+++ b/src/controllers/v2/NamespaceDirectoryController.ts
@@ -10,7 +10,11 @@ import {
 } from 'tsoa';
 import { KeystoneService } from '../ioc/keystoneInjector';
 import { inject, injectable } from 'tsyringe';
-import { transform, transformSetAnonymous } from './DirectoryController';
+import {
+  transform,
+  transformSetAnonymous,
+  transformSetTwoTieredHidden,
+} from './DirectoryController';
 import { gql } from 'graphql-request';
 import { strict as assert } from 'assert';
 
@@ -55,7 +59,9 @@ export class NamespaceDirectoryController extends Controller {
     );
 
     return transform(
-      transformSetAnonymous(result.data.allProductsByNamespace)
+      transformSetTwoTieredHidden(
+        transformSetAnonymous(result.data.allProductsByNamespace)
+      )
     )[0];
   }
 

--- a/src/controllers/v3/DirectoryController.ts
+++ b/src/controllers/v3/DirectoryController.ts
@@ -43,9 +43,41 @@ export class DirectoryController extends Controller {
     }
 
     return transform(
-      transformSetAnonymous(result.data.allDiscoverableProducts)
+      transformRemoveServices(
+        transformSetTwoTieredHidden(
+          transformSetAnonymous(result.data.allDiscoverableProducts)
+        )
+      )
     )[0];
   }
+}
+
+export function transformRemoveServices(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      removeKeys(env, ['services']);
+    });
+  });
+  return products;
+}
+
+export function transformSetTwoTieredHidden(products: Product[]) {
+  products.forEach((prod) => {
+    prod.environments.forEach((env) => {
+      env.services.forEach((svc) => {
+        svc.plugins?.forEach((plugin) => {
+          if (plugin.tags) {
+            // Tags come from GraphQL as JSON strings, need to parse them
+            const tags: string[] = JSON.parse(plugin.tags);
+            if (tags.includes('aps.two-tiered-hidden')) {
+              (env as any).twoTieredHidden = true;
+            }
+          }
+        });
+      });
+    });
+  });
+  return products;
 }
 
 export function transformSetAnonymous(products: Product[]) {

--- a/src/controllers/v3/GatewayDirectoryController.ts
+++ b/src/controllers/v3/GatewayDirectoryController.ts
@@ -10,7 +10,11 @@ import {
 } from 'tsoa';
 import { KeystoneService } from '../ioc/keystoneInjector';
 import { inject, injectable } from 'tsyringe';
-import { transform, transformSetAnonymous } from './DirectoryController';
+import {
+  transform,
+  transformSetAnonymous,
+  transformSetTwoTieredHidden,
+} from './DirectoryController';
 import { gql } from 'graphql-request';
 import { strict as assert } from 'assert';
 
@@ -55,7 +59,9 @@ export class GatewayDirectoryController extends Controller {
     );
 
     return transform(
-      transformSetAnonymous(result.data.allProductsByNamespace)
+      transformSetTwoTieredHidden(
+        transformSetAnonymous(result.data.allProductsByNamespace)
+      )
     )[0];
   }
 

--- a/src/nextapp/components/api-product-item/api-product-item.tsx
+++ b/src/nextapp/components/api-product-item/api-product-item.tsx
@@ -18,6 +18,7 @@ import { Dataset, Environment, Product } from '@/shared/types/query.types';
 
 export interface ApiEnvironment extends Environment {
   anonymous: boolean;
+  twoTieredHidden?: boolean;
 }
 
 export interface ApiProduct extends Product {
@@ -45,11 +46,7 @@ const ApiProductItem: React.FC<ApiProductItemProps> = ({
   );
   const isTiered = data.environments.some((e) => e.anonymous);
 
-  const isTieredHidden = data.environments.some((e) =>
-    e.services.some((s) =>
-      s.plugins.some((p) => p.tags.includes('aps.two-tiered-hidden'))
-    )
-  );
+  const isTieredHidden = data.environments.some((e) => e.twoTieredHidden);
 
   return (
     <>
@@ -59,11 +56,11 @@ const ApiProductItem: React.FC<ApiProductItemProps> = ({
             <Flex align="center" mb={2}>
               <Flex align="center" width={8}>
                 <Icon
-                  as={isPublic || isTiered ? RiEarthFill : FaLock}
+                  as={isPublic || isTiered && !isTieredHidden ? RiEarthFill : FaLock}
                   color="bc-blue"
                   boxSize="5"
                   data-testid={`product-icon-${kebabCase(data.name)}-${
-                    isPublic || isTiered ? 'RiEarthFill' : 'FaLock'
+                    isPublic || isTiered && !isTieredHidden ? 'RiEarthFill' : 'FaLock'
                   }`}
                 />
               </Flex>

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -125,7 +125,7 @@
         "@typescript-eslint/eslint-plugin": "^4.13.0",
         "@typescript-eslint/parser": "^4.13.0",
         "babel-jest": "^27.5.1",
-        "babel-loader": "^8.3.0",
+        "babel-loader": "^8.2.2",
         "babel-plugin-istanbul": "^6.1.1",
         "casual-browserify": "^1.5.19-2",
         "chai": "^4.1.2",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -60,6 +60,7 @@
         "keycloak-connect": "^17.0.1",
         "lodash": "^4.17.21",
         "multer": "^1.4.2",
+        "node-fetch": "^2.7.0",
         "nodemailer": "^6.6.0",
         "npmlog": "^6.0.1",
         "numeral": "^2.0.6",
@@ -124,7 +125,7 @@
         "@typescript-eslint/eslint-plugin": "^4.13.0",
         "@typescript-eslint/parser": "^4.13.0",
         "babel-jest": "^27.5.1",
-        "babel-loader": "^8.2.2",
+        "babel-loader": "^8.3.0",
         "babel-plugin-istanbul": "^6.1.1",
         "casual-browserify": "^1.5.19-2",
         "chai": "^4.1.2",
@@ -153,7 +154,7 @@
         "typescript": "4.2.4"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=22.0.0 <23.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5471,6 +5472,15 @@
         "node-fetch": "2.6.1"
       }
     },
+    "node_modules/@graphql-tools/links/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/@graphql-tools/load": {
       "version": "6.2.8",
       "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-6.2.8.tgz",
@@ -5839,6 +5849,15 @@
       "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "dependencies": {
         "node-fetch": "2.6.1"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/@graphql-tools/url-loader/node_modules/tslib": {
@@ -9512,6 +9531,15 @@
         }
       }
     },
+    "node_modules/@keystonejs/app-admin-ui/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/@keystonejs/app-admin-ui/node_modules/pg-connection-string": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
@@ -10237,6 +10265,15 @@
         "tedious": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@keystonejs/fields-auto-increment/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/@keystonejs/fields-auto-increment/node_modules/pg-connection-string": {
@@ -11060,6 +11097,15 @@
         }
       }
     },
+    "node_modules/@keystonejs/fields-mongoid/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/@keystonejs/fields-mongoid/node_modules/pg-connection-string": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
@@ -11802,6 +11848,15 @@
         "tedious": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@keystonejs/fields/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/@keystonejs/fields/node_modules/pg-connection-string": {
@@ -12842,6 +12897,15 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@prisma/sdk/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/@prisma/sdk/node_modules/supports-color": {
@@ -18813,12 +18877,13 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
-      "integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
+      "integrity": "sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==",
+      "license": "MIT",
       "dependencies": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^1.4.0",
+        "loader-utils": "^2.0.4",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
       },
@@ -18830,28 +18895,18 @@
         "webpack": ">=2"
       }
     },
-    "node_modules/babel-loader/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/babel-loader/node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
+        "json5": "^2.1.2"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=8.9.0"
       }
     },
     "node_modules/babel-loader/node_modules/schema-utils": {
@@ -20557,6 +20612,15 @@
         "uuid": "8.3.0"
       }
     },
+    "node_modules/checkpoint-client/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/checkpoint-client/node_modules/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
@@ -22052,6 +22116,15 @@
         "node-fetch": "2.6.1"
       }
     },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -22078,50 +22151,12 @@
         "web-streams-polyfill": "^3.2.0"
       }
     },
-    "node_modules/cross-undici-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cross-undici-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o= sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/cross-undici-fetch/node_modules/undici": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
       "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
       "engines": {
         "node": ">=12.18"
-      }
-    },
-    "node_modules/cross-undici-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE= sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/cross-undici-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0= sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/cryptiles": {
@@ -37716,11 +37751,45 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-fingerprint": {
@@ -53337,6 +53406,11 @@
           "requires": {
             "node-fetch": "2.6.1"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -53665,6 +53739,11 @@
           "requires": {
             "node-fetch": "2.6.1"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "tslib": {
           "version": "2.2.0",
@@ -56513,6 +56592,11 @@
             "tildify": "2.0.0"
           }
         },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
         "pg-connection-string": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
@@ -57232,6 +57316,11 @@
             "tildify": "2.0.0"
           }
         },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
         "pg-connection-string": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
@@ -57650,6 +57739,11 @@
             "tarn": "^3.0.1",
             "tildify": "2.0.0"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "pg-connection-string": {
           "version": "2.5.0",
@@ -58310,6 +58404,11 @@
             "tarn": "^3.0.1",
             "tildify": "2.0.0"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "pg-connection-string": {
           "version": "2.5.0",
@@ -59113,6 +59212,11 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -63769,32 +63873,24 @@
       }
     },
     "babel-loader": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
-      "integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
+      "integrity": "sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==",
       "requires": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^1.4.0",
+        "loader-utils": "^2.0.4",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
       },
       "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
+            "json5": "^2.1.2"
           }
         },
         "schema-utils": {
@@ -65185,6 +65281,11 @@
         "uuid": "8.3.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
         "uuid": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
@@ -66395,6 +66496,13 @@
       "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
       "requires": {
         "node-fetch": "2.6.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
       }
     },
     "cross-spawn": {
@@ -66420,37 +66528,10 @@
         "web-streams-polyfill": "^3.2.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o= sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
         "undici": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
           "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg=="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE= sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0= sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
         }
       }
     },
@@ -78441,9 +78522,33 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-fingerprint": {
       "version": "0.0.2",

--- a/src/package.json
+++ b/src/package.json
@@ -175,7 +175,7 @@
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
     "babel-jest": "^27.5.1",
-    "babel-loader": "^8.2.2",
+    "babel-loader": "^8.3.0",
     "babel-plugin-istanbul": "^6.1.1",
     "casual-browserify": "^1.5.19-2",
     "chai": "^4.1.2",

--- a/src/package.json
+++ b/src/package.json
@@ -175,7 +175,7 @@
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
     "babel-jest": "^27.5.1",
-    "babel-loader": "^8.3.0",
+    "babel-loader": "^8.2.2",
     "babel-plugin-istanbul": "^6.1.1",
     "casual-browserify": "^1.5.19-2",
     "chai": "^4.1.2",

--- a/src/test/services/batch/integrated-batch.test.ts
+++ b/src/test/services/batch/integrated-batch.test.ts
@@ -89,9 +89,11 @@ describe('Batch Tests', function () {
         }
       } catch (e) {
         logger.error(e.message);
+        logger.error('"%s" "%s"', test.expected?.exception, `${e.message}`);
+        // node 22+ assert includes the values used in the comparison
         if (
           !test.expected?.exception ||
-          test.expected?.exception != `${e.message}`
+          test.expected?.exception !== `${e.message}`
         ) {
           await keystone.disconnect();
 

--- a/src/test/services/batch/testdata.js
+++ b/src/test/services/batch/testdata.js
@@ -81,7 +81,7 @@ export default {
         payload: {
           status: 400,
           result: 'update-failed',
-          reason: 'Failed updating children',
+          reason: 'Failed updating children\n\n1 !== 0\n',
           childResults: [
             {
               status: 400,
@@ -210,7 +210,7 @@ export default {
       data: {
         namespace: 'refactortime',
       },
-      expected: { exception: 'Missing value for key name' },
+      expected: { exception: 'Missing value for key name\n\nfalse !== true\n' },
     },
     {
       name: 'create a new product with lots of environments',

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -671,12 +671,13 @@
   dependencies:
     tslib "~2.0.1"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.24.6", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz"
+  integrity sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==
   dependencies:
-    "@babel/highlight" "^7.16.7"
+    "@babel/highlight" "^7.24.6"
+    picocolors "^1.0.0"
 
 "@babel/code-frame@7.10.4":
   version "7.10.4"
@@ -784,12 +785,12 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.16.0", "@babel/helper-annotate-as-pure@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz"
-  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
+"@babel/helper-annotate-as-pure@^7.16.0", "@babel/helper-annotate-as-pure@^7.16.7", "@babel/helper-annotate-as-pure@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz"
+  integrity sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==
   dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.24.6"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.16.7":
   version "7.16.7"
@@ -810,17 +811,19 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.6", "@babel/helper-create-class-features-plugin@^7.17.9":
-  version "7.17.9"
-  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz"
-  integrity sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.6.tgz"
+  integrity sha512-djsosdPJVZE6Vsw3kk7IPRWethP94WHGOhQTc67SNXE0ZzMhHgALw8iGmYS0TD1bbMM0VDROy43od7/hN6WYcA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.7"
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.17.9"
-    "@babel/helper-member-expression-to-functions" "^7.17.7"
-    "@babel/helper-optimise-call-expression" "^7.16.7"
-    "@babel/helper-replace-supers" "^7.16.7"
-    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/helper-annotate-as-pure" "^7.24.6"
+    "@babel/helper-environment-visitor" "^7.24.6"
+    "@babel/helper-function-name" "^7.24.6"
+    "@babel/helper-member-expression-to-functions" "^7.24.6"
+    "@babel/helper-optimise-call-expression" "^7.24.6"
+    "@babel/helper-replace-supers" "^7.24.6"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.24.6"
+    "@babel/helper-split-export-declaration" "^7.24.6"
+    semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.16.7":
   version "7.17.0"
@@ -858,12 +861,10 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
-"@babel/helper-environment-visitor@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz"
-  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
-  dependencies:
-    "@babel/types" "^7.16.7"
+"@babel/helper-environment-visitor@^7.16.7", "@babel/helper-environment-visitor@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.6.tgz"
+  integrity sha512-Y50Cg3k0LKLMjxdPjIl40SdJgMB85iXn27Vk/qbHZCFx/o5XO3PSnpi675h1KEmmDb6OFArfd5SCQEQ5Q4H88g==
 
 "@babel/helper-explode-assignable-expression@^7.16.7":
   version "7.16.7"
@@ -872,13 +873,13 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-function-name@^7.12.11", "@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.17.9":
-  version "7.17.9"
-  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz"
-  integrity sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==
+"@babel/helper-function-name@^7.12.11", "@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.17.9", "@babel/helper-function-name@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.6.tgz"
+  integrity sha512-xpeLqeeRkbxhnYimfr2PC+iA0Q7ljX/d1eZ9/inYbmfG2jpl8Lu3DyXvpOAnrS5kxkfOWJjioIMQsaMBXFI05w==
   dependencies:
-    "@babel/template" "^7.16.7"
-    "@babel/types" "^7.17.0"
+    "@babel/template" "^7.24.6"
+    "@babel/types" "^7.24.6"
 
 "@babel/helper-hoist-variables@^7.16.7":
   version "7.16.7"
@@ -887,12 +888,12 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-member-expression-to-functions@^7.16.7", "@babel/helper-member-expression-to-functions@^7.17.7":
-  version "7.17.7"
-  resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz"
-  integrity sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==
+"@babel/helper-member-expression-to-functions@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.6.tgz"
+  integrity sha512-OTsCufZTxDUsv2/eDXanw/mUZHWOxSbEmC3pP8cgjcy5rgeVPWWMStnv274DV60JtHxTk0adT0QrCzC4M9NWGg==
   dependencies:
-    "@babel/types" "^7.17.0"
+    "@babel/types" "^7.24.6"
 
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.0", "@babel/helper-module-imports@^7.16.7":
   version "7.16.7"
@@ -915,17 +916,17 @@
     "@babel/traverse" "^7.17.3"
     "@babel/types" "^7.17.0"
 
-"@babel/helper-optimise-call-expression@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz"
-  integrity sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==
+"@babel/helper-optimise-call-expression@^7.16.7", "@babel/helper-optimise-call-expression@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.6.tgz"
+  integrity sha512-3SFDJRbx7KuPRl8XDUr8O7GAEB8iGyWPjLKJh/ywP/Iy9WOmEfMrsWbaZpvBu2HSYn4KQygIsz0O7m8y10ncMA==
   dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.24.6"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.16.7", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz"
-  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.6.tgz"
+  integrity sha512-MZG/JcWfxybKwsA9N9PmtF2lOSFSEMVCpIRrbxccZFLJPrJciJdG/UhSh5W96GEteJI2ARqm5UAHxISwRDLSNg==
 
 "@babel/helper-plugin-utils@7.10.4":
   version "7.10.4"
@@ -941,16 +942,14 @@
     "@babel/helper-wrap-function" "^7.16.8"
     "@babel/types" "^7.16.8"
 
-"@babel/helper-replace-supers@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz"
-  integrity sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==
+"@babel/helper-replace-supers@^7.16.7", "@babel/helper-replace-supers@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.6.tgz"
+  integrity sha512-mRhfPwDqDpba8o1F8ESxsEkJMQkUF8ZIWrAc0FtWhxnjfextxMWxr22RtFizxxSYLjVHDeMgVsRq8BBZR2ikJQ==
   dependencies:
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-member-expression-to-functions" "^7.16.7"
-    "@babel/helper-optimise-call-expression" "^7.16.7"
-    "@babel/traverse" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/helper-environment-visitor" "^7.24.6"
+    "@babel/helper-member-expression-to-functions" "^7.24.6"
+    "@babel/helper-optimise-call-expression" "^7.24.6"
 
 "@babel/helper-simple-access@^7.10.4", "@babel/helper-simple-access@^7.17.7":
   version "7.17.7"
@@ -959,24 +958,29 @@
   dependencies:
     "@babel/types" "^7.17.0"
 
-"@babel/helper-skip-transparent-expression-wrappers@^7.12.1", "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz"
-  integrity sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==
+"@babel/helper-skip-transparent-expression-wrappers@^7.12.1", "@babel/helper-skip-transparent-expression-wrappers@^7.16.0", "@babel/helper-skip-transparent-expression-wrappers@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.6.tgz"
+  integrity sha512-jhbbkK3IUKc4T43WadP96a27oYti9gEf1LdyGSP2rHGH77kwLwfhO7TgwnWvxxQVmke0ImmCSS47vcuxEMGD3Q==
   dependencies:
-    "@babel/types" "^7.16.0"
+    "@babel/types" "^7.24.6"
 
-"@babel/helper-split-export-declaration@^7.12.11", "@babel/helper-split-export-declaration@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz"
-  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+"@babel/helper-split-export-declaration@^7.12.11", "@babel/helper-split-export-declaration@^7.16.7", "@babel/helper-split-export-declaration@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz"
+  integrity sha512-CvLSkwXGWnYlF9+J3iZUvwgAxKiYzK3BWuo+mLzD/MDGOZDj7Gq8+hqaOkMxmJwmlv0iu86uH5fdADd9Hxkymw==
   dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.24.6"
 
-"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+"@babel/helper-string-parser@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz"
+  integrity sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==
+
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz"
+  integrity sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==
 
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.14.5", "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
@@ -1002,19 +1006,20 @@
     "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
-  version "7.17.9"
-  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz"
-  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.24.6":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz"
+  integrity sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
+    "@babel/helper-validator-identifier" "^7.24.6"
+    chalk "^2.4.2"
     js-tokens "^4.0.0"
+    picocolors "^1.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.16.7", "@babel/parser@^7.17.9", "@babel/parser@^7.7.7":
-  version "7.17.9"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz"
-  integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.17.9", "@babel/parser@^7.24.6", "@babel/parser@^7.7.7":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.24.6.tgz"
+  integrity sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==
 
 "@babel/parser@7.12.11":
   version "7.12.11"
@@ -2149,16 +2154,16 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.3.3", "@babel/template@^7.7.4":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz"
-  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+"@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.24.6", "@babel/template@^7.3.3", "@babel/template@^7.7.4":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.24.6.tgz"
+  integrity sha512-3vgazJlLwNXi9jhrR1ef8qiB65L1RK90+lEQwv4OxveHnqC3BfmnHdgySwRLzf6akhlOYenT+b7AfWq+a//AHw==
   dependencies:
-    "@babel/code-frame" "^7.16.7"
-    "@babel/parser" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/code-frame" "^7.24.6"
+    "@babel/parser" "^7.24.6"
+    "@babel/types" "^7.24.6"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4":
   version "7.17.9"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz"
   integrity sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==
@@ -2189,12 +2194,13 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.17.0"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz"
-  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+"@babel/types@^7.0.0", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.24.6", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.24.6.tgz"
+  integrity sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-string-parser" "^7.24.6"
+    "@babel/helper-validator-identifier" "^7.24.6"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.11.5", "@babel/types@^7.7.4", "@babel/types@7.11.5":
@@ -8461,13 +8467,13 @@ babel-jest@^27.5.1:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-loader@^8.0.0, babel-loader@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz"
-  integrity sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==
+babel-loader@^8.0.0, babel-loader@^8.2.2, babel-loader@^8.3.0:
+  version "8.4.1"
+  resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz"
+  integrity sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==
   dependencies:
     find-cache-dir "^3.3.1"
-    loader-utils "^1.4.0"
+    loader-utils "^2.0.4"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
@@ -8813,13 +8819,6 @@ binary@~0.3.0:
   dependencies:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
-
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
 
 bl@^2.2.1:
   version "2.2.1"
@@ -9451,7 +9450,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -13083,19 +13082,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8= sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^1.2.7:
-  version "1.2.13"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
-  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.12.1"
-
-fsevents@^2.1.2, fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz"
@@ -16366,19 +16352,19 @@ loader-utils@^1.2.3:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
-
 loader-utils@^2.0.0, loader-utils@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz"
   integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
+loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
@@ -17607,11 +17593,6 @@ mute-stream@0.0.8:
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1:
-  version "2.14.2"
-  resolved "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz"
-  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
-
 nanoassert@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz"
@@ -17792,15 +17773,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -17808,6 +17784,11 @@ node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@2.6.7:
   version "2.6.7"
@@ -21406,10 +21387,10 @@ semver@^5.7.1:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0, semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.2.1:
   version "7.3.6"

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -8467,7 +8467,7 @@ babel-jest@^27.5.1:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-loader@^8.0.0, babel-loader@^8.2.2, babel-loader@^8.3.0:
+babel-loader@^8.0.0, babel-loader@^8.2.2:
   version "8.4.1"
   resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz"
   integrity sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==


### PR DESCRIPTION
Note: supercedes https://github.com/bcgov/api-services-portal/pull/1335 - branch name was too long, causing helm issues

## Summary

This PR sanitizes the Directory API response by removing the `services` payload and extracts the `twoTieredHidden` flag from plugin tags before services are removed. The UI is updated to use the extracted flag instead of accessing services directly.

The behaviour for two-tiered-hidden products is changed to show a lock icon instead of an earth (implying public), thereby _actually_ hiding two-tiered access. I couldn't find any tickets documenting the initial request or requirements from LOC, but noone is currently using this feature and I feel this is a more logical approach for potential future users.

Fixes #1334 

## Changes

### API Controllers
- **Remove services from directory API responses** to reduce payload size
- **Extract `twoTieredHidden` flag** from plugin tags (`aps.two-tiered-hidden`) before removing services
- Apply changes to:
  - v2 and v3 Directory and GatewayDirectory/NamespaceDirectory controllers
  - v1 not updated: no longer available

### Frontend
- Update `api-product-item` component to use `twoTieredHidden` property instead of accessing services
- Show lock icon (FaLock) for two-tiered-hidden products instead of public icon (RiEarthFill)

## Other Updates
- Fixed minor validation error regressions introduced in https://github.com/bcgov/api-services-portal/pull/1311
- Local Kong version bump (3.9.0 → 3.9.1) and added curl to Dockerfile (fix build issue)
- README: Added WSL hostip command for OAuth2 proxy setup
- Updated e2e tests to expect lock icon for two-tiered-hidden products

---
🚀 Feature branch deployment: https://api-services-portal-feature-remove-services.apps.silver.devops.gov.bc.ca

---
🚀 Feature branch deployment: https://api-services-portal-feature-remove-services.apps.silver.devops.gov.bc.ca