### PR TITLE
Add NPM_TOKEN

### DIFF
--- a/.github/workflows/aps-cypress-e2e.yaml
+++ b/.github/workflows/aps-cypress-e2e.yaml
@@ -16,6 +16,8 @@ env:
   GIT_COMMIT_AUTHOR: ${{ github.actor }}
   GIT_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
   GIT_REPO_URL: ${{ github.repository }}
+  # Optional: avoids npm 403 from registry when multiple images run npm install in parallel
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   cypress-run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     build:
       context: .
       dockerfile: ./local/portal/Dockerfile.E2E
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     env_file:
       - .env.local
     ports:
@@ -80,6 +82,8 @@ services:
     build:
       context: ./feeds
       dockerfile: Dockerfile
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     env_file:
       - ./local/feeds/.env.local
     restart: on-failure
@@ -208,6 +212,8 @@ services:
     build:
       context: ./local/cypress-jwks-url
       dockerfile: Dockerfile
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     volumes:
       - ./local/cypress-jwks-url:/src
     command: npm start
@@ -237,6 +243,8 @@ services:
     build:
       context: .
       dockerfile: e2e/Dockerfile
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     volumes:
       - ./e2e/coverage:/e2e/coverage
       - ./e2e/results:/e2e/results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ x-common-variables: &common-variables
   KONG_PG_USER: konguser
   KONG_PG_PASSWORD: konguser
 
+secrets:
+  npm_token:
+    environment: "NPM_TOKEN"
+
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:15.1.1
@@ -64,8 +68,8 @@ services:
     build:
       context: .
       dockerfile: ./local/portal/Dockerfile.E2E
-      args:
-        NPM_TOKEN: ${NPM_TOKEN:-}
+      secrets:
+        - npm_token
     env_file:
       - .env.local
     ports:
@@ -82,8 +86,8 @@ services:
     build:
       context: ./feeds
       dockerfile: Dockerfile
-      args:
-        NPM_TOKEN: ${NPM_TOKEN:-}
+      secrets:
+        - npm_token
     env_file:
       - ./local/feeds/.env.local
     restart: on-failure
@@ -212,8 +216,8 @@ services:
     build:
       context: ./local/cypress-jwks-url
       dockerfile: Dockerfile
-      args:
-        NPM_TOKEN: ${NPM_TOKEN:-}
+      secrets:
+        - npm_token
     volumes:
       - ./local/cypress-jwks-url:/src
     command: npm start
@@ -243,8 +247,8 @@ services:
     build:
       context: .
       dockerfile: e2e/Dockerfile
-      args:
-        NPM_TOKEN: ${NPM_TOKEN:-}
+      secrets:
+        - npm_token
     volumes:
       - ./e2e/coverage:/e2e/coverage
       - ./e2e/results:/e2e/results

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,13 +1,12 @@
 FROM cypress/included:13.17.0
 
-ARG NPM_TOKEN
-RUN if [ -n "$NPM_TOKEN" ]; then npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN; fi
-
 # Copy of the source for code coverage analysis
 WORKDIR /app
 COPY src/. ./
 
-RUN npm install --legacy-peer-deps
+RUN --mount=type=secret,id=npm_token \
+  ( [ ! -s /run/secrets/npm_token ] || npm config set //registry.npmjs.org/:_authToken="$(cat /run/secrets/npm_token)" ) && \
+  npm install --legacy-peer-deps
 
 RUN npx nyc instrument --compact=false . --in-place
 
@@ -17,7 +16,9 @@ WORKDIR /e2e
 RUN apt-get -y update; apt-get -y install curl
 COPY e2e/package.json /e2e
 COPY e2e/package-lock.json /e2e
-RUN npm install
+RUN --mount=type=secret,id=npm_token \
+  ( [ ! -s /run/secrets/npm_token ] || npm config set //registry.npmjs.org/:_authToken="$(cat /run/secrets/npm_token)" ) && \
+  npm install
 
 COPY e2e/cypress.config.ts /e2e
 COPY e2e/tsconfig.json /e2e

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,5 +1,8 @@
 FROM cypress/included:13.17.0
 
+ARG NPM_TOKEN
+RUN if [ -n "$NPM_TOKEN" ]; then npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN; fi
+
 # Copy of the source for code coverage analysis
 WORKDIR /app
 COPY src/. ./

--- a/feeds/Dockerfile
+++ b/feeds/Dockerfile
@@ -3,9 +3,6 @@ FROM node:22.12.0-alpine3.21
 
 RUN apk add curl jq
 
-ARG NPM_TOKEN
-RUN if [ -n "$NPM_TOKEN" ]; then npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN; fi
-
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 
@@ -15,7 +12,9 @@ ENV APP_REVISION=${APP_REVISION}
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN --mount=type=secret,id=npm_token \
+  ( [ ! -s /run/secrets/npm_token ] || npm config set //registry.npmjs.org/:_authToken="$(cat /run/secrets/npm_token)" ) && \
+  npm install
 
 COPY . ./
 

--- a/feeds/Dockerfile
+++ b/feeds/Dockerfile
@@ -3,6 +3,9 @@ FROM node:22.12.0-alpine3.21
 
 RUN apk add curl jq
 
+ARG NPM_TOKEN
+RUN if [ -n "$NPM_TOKEN" ]; then npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN; fi
+
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 

--- a/local/cypress-jwks-url/Dockerfile
+++ b/local/cypress-jwks-url/Dockerfile
@@ -1,15 +1,14 @@
 FROM node:22.12.0-alpine3.21
 
-ARG NPM_TOKEN
-RUN if [ -n "$NPM_TOKEN" ]; then npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN; fi
-
 WORKDIR /src
 
 COPY package*.json /
 
 EXPOSE 3500
 
-RUN npm install
+RUN --mount=type=secret,id=npm_token \
+  ( [ ! -s /run/secrets/npm_token ] || npm config set //registry.npmjs.org/:_authToken="$(cat /run/secrets/npm_token)" ) && \
+  npm install
 
 COPY . /
 

--- a/local/cypress-jwks-url/Dockerfile
+++ b/local/cypress-jwks-url/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22.12.0-alpine3.21
 
+ARG NPM_TOKEN
+RUN if [ -n "$NPM_TOKEN" ]; then npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN; fi
+
 WORKDIR /src
 
 COPY package*.json /

--- a/local/portal/Dockerfile.E2E
+++ b/local/portal/Dockerfile.E2E
@@ -1,6 +1,7 @@
 #FROM node:lts-alpine3.18
 FROM node:22.12.0-alpine3.21
 
+ARG NPM_TOKEN
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 
@@ -16,7 +17,7 @@ COPY --chown=node src/*.json ./
 
 COPY --chown=node src/nyc.config.js ./
 
-RUN npm install --legacy-peer-deps
+RUN ( [ -z "$NPM_TOKEN" ] || npm config set //registry.npmjs.org/:_authToken="$NPM_TOKEN" ) && npm install --legacy-peer-deps
 
 COPY --chown=node src ./
 

--- a/local/portal/Dockerfile.E2E
+++ b/local/portal/Dockerfile.E2E
@@ -1,7 +1,6 @@
 #FROM node:lts-alpine3.18
 FROM node:22.12.0-alpine3.21
 
-ARG NPM_TOKEN
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 
@@ -17,7 +16,11 @@ COPY --chown=node src/*.json ./
 
 COPY --chown=node src/nyc.config.js ./
 
-RUN ( [ -z "$NPM_TOKEN" ] || npm config set //registry.npmjs.org/:_authToken="$NPM_TOKEN" ) && npm install --legacy-peer-deps
+USER root
+RUN --mount=type=secret,id=npm_token \
+  ( [ ! -s /run/secrets/npm_token ] || npm config set //registry.npmjs.org/:_authToken="$(cat /run/secrets/npm_token)" ) && \
+  npm install --legacy-peer-deps && chown -R node:node /app
+USER node
 
 COPY --chown=node src ./
 


### PR DESCRIPTION
Fixes 403 Forbidden on Cypress tests.

The 403 Forbidden happens when the npm registry rate-limits unauthenticated requests. In our workflow, several images run npm install in parallel (cypress-jwks-url, feeder, apsportal, cypress, etc.), so the runner hits that limit and npm returns 403.