### PR TITLE
APS-4406 - don't get service metrics when value is zero

### DIFF
--- a/feeds/prometheus/index.js
+++ b/feeds/prometheus/index.js
@@ -8,12 +8,12 @@ const log = Logger('prometheus');
 
 const queryRanges = [
   {
-    query: 'sum(increase(kong_http_requests_total[1d])) by (service,code)',
+    query: 'sum(increase(kong_http_requests_total[1d])) by (service,code) != 0',
     step: 60 * 60 * 24,
     id: 'kong_http_requests_daily_service_code',
   },
   {
-    query: 'sum(increase(kong_http_requests_total[60m])) by (service,namespace)',
+    query: 'sum(increase(kong_http_requests_total[60m])) by (service,namespace) != 0',
     step: 60 * 60,
     id: 'kong_http_requests_hourly_service',
   },
@@ -34,7 +34,7 @@ const queryRanges = [
   },
   {
     query:
-      'sum(increase(konglog_service_consumer_counter[60m])) by (consumer,service)',
+      'sum(increase(konglog_service_consumer_counter[60m])) by (consumer,service) != 0',
     step: 60 * 60,
     id: 'konglog_service_consumer_hourly',
   },

--- a/src/nextapp/components/services-list/metric-graph.tsx
+++ b/src/nextapp/components/services-list/metric-graph.tsx
@@ -80,27 +80,25 @@ const MetricGraph: React.FC<MetricGraphProps> = ({
     color: 'gray.400',
     textTransform: 'none',
   };
-  const values: number[][] =
+  const metrics =
     data?.allGatewayServiceMetricsByNamespace
-      .slice(0, 5)
-      .map((metric: Metric) => {
-        return JSON.parse(metric.values);
-      }) ?? [];
+      .slice(0, 5) ?? [];
 
-  const dailies: DailyDatum[] = values.map((value: number[]) => {
-    const firstDateValue = new Date(value[0][0] * 1000);
-    const day = formatISO(firstDateValue, {
+  const dailies: DailyDatum[] = metrics.map((metric: Metric) => {
+    const value: number[][] = JSON.parse(metric.values);
+    const dayStart = new Date(`${metric.day}T00:00:00.000Z`);
+    const day = formatISO(dayStart, {
       representation: 'date',
     });
     const total: number = value.reduce((memo: number, v) => {
       return memo + Number(v[1]);
     }, 0);
-    const downtime = 24 - values.length;
-    const defaultPeakDate: number = firstDateValue.getTime();
-    const peak: number | [number, number] = value.reduce(
+    const downtime = 24 - value.length;
+    const defaultPeakDate: number = dayStart.getTime();
+    const peak: [number, number] = value.reduce<[number, number]>(
       (memo, v) => {
         if (memo[1] < Number(v[1])) {
-          return v;
+          return v as [number, number];
         }
         return memo;
       },
@@ -110,7 +108,7 @@ const MetricGraph: React.FC<MetricGraphProps> = ({
     const requests = [];
 
     times(24, (h) => {
-      const timestampKey = addHours(new Date(firstDateValue), h).getTime();
+      const timestampKey = addHours(new Date(dayStart), h).getTime();
       const request = value.find((v) => v[0] === timestampKey / 1000);
 
       if (request) {
@@ -122,8 +120,8 @@ const MetricGraph: React.FC<MetricGraphProps> = ({
 
     return {
       day,
-      date: firstDateValue,
-      dayFormatted: graphDate.format(firstDateValue),
+      date: dayStart,
+      dayFormatted: graphDate.format(dayStart),
       // TODO: possibly remove, just keep around incase
       // dayFormattedShort: format(new Date(firstDateValue), 'LLL d'),
       downtime,

--- a/src/nextapp/components/services-list/metric-graph.tsx
+++ b/src/nextapp/components/services-list/metric-graph.tsx
@@ -80,25 +80,27 @@ const MetricGraph: React.FC<MetricGraphProps> = ({
     color: 'gray.400',
     textTransform: 'none',
   };
-  const metrics =
+  const values: number[][] =
     data?.allGatewayServiceMetricsByNamespace
-      .slice(0, 5) ?? [];
+      .slice(0, 5)
+      .map((metric: Metric) => {
+        return JSON.parse(metric.values);
+      }) ?? [];
 
-  const dailies: DailyDatum[] = metrics.map((metric: Metric) => {
-    const value: number[][] = JSON.parse(metric.values);
-    const dayStart = new Date(`${metric.day}T00:00:00.000Z`);
-    const day = formatISO(dayStart, {
+  const dailies: DailyDatum[] = values.map((value: number[]) => {
+    const firstDateValue = new Date(value[0][0] * 1000);
+    const day = formatISO(firstDateValue, {
       representation: 'date',
     });
     const total: number = value.reduce((memo: number, v) => {
       return memo + Number(v[1]);
     }, 0);
-    const downtime = 24 - value.length;
-    const defaultPeakDate: number = dayStart.getTime();
-    const peak: [number, number] = value.reduce<[number, number]>(
+    const downtime = 24 - values.length;
+    const defaultPeakDate: number = firstDateValue.getTime();
+    const peak: number | [number, number] = value.reduce(
       (memo, v) => {
         if (memo[1] < Number(v[1])) {
-          return v as [number, number];
+          return v;
         }
         return memo;
       },
@@ -108,7 +110,7 @@ const MetricGraph: React.FC<MetricGraphProps> = ({
     const requests = [];
 
     times(24, (h) => {
-      const timestampKey = addHours(new Date(dayStart), h).getTime();
+      const timestampKey = addHours(new Date(firstDateValue), h).getTime();
       const request = value.find((v) => v[0] === timestampKey / 1000);
 
       if (request) {
@@ -120,8 +122,8 @@ const MetricGraph: React.FC<MetricGraphProps> = ({
 
     return {
       day,
-      date: dayStart,
-      dayFormatted: graphDate.format(dayStart),
+      date: firstDateValue,
+      dayFormatted: graphDate.format(firstDateValue),
       // TODO: possibly remove, just keep around incase
       // dayFormattedShort: format(new Date(firstDateValue), 'LLL d'),
       downtime,


### PR DESCRIPTION
The main change here is to avoid errors in batch (which are then passed on to feeder) - the prom queries are changed to only get non-zero values.

Another change is required in `metrics-graph` to avoid shifting the daily metrics to the left if there were zero values at the start of the day.  Rather than deriving the start of the day from the first data point (which especially now, may not be at hour 0), instead we use the day field to calculate the correct start timestamp (midnight of that day).