### PR TITLE
Cypress Fixes

### DIFF
--- a/e2e/cypress/pageObjects/keycloakUsers.ts
+++ b/e2e/cypress/pageObjects/keycloakUsers.ts
@@ -19,7 +19,7 @@ class keycloakUsersPage {
   setUserToOrganization(orgName: string) {
     cy.contains('Join Group').click()
     cy.get('input[placeholder="Search group"]').type(orgName).type('{enter}')
-    cy.get(`input[data-testid="${orgName}-check"]`).click()
+    cy.get(`input[data-testid="${orgName}-check"]`).first().click()
     cy.get('[data-testid="join-button"]').click()
   }
 

--- a/e2e/cypress/tests/19-api-v3/01-api-directory.ts
+++ b/e2e/cypress/tests/19-api-v3/01-api-directory.ts
@@ -78,7 +78,7 @@ describe('API Directory', () => {
               organization: {
                 name: org.name,
                 title: 'Some good title about kittens',
-                tags: [],
+                tags: org.tags,
                 description: 'Some good description about kittens',
               },
               organizationUnit: {
@@ -176,7 +176,7 @@ describe('API Directory', () => {
           organization: {
             name: org.name,
             title: 'Some good title about kittens',
-            tags: [],
+            tags: org.tags,
             description: 'Some good description about kittens',
           },
           organizationUnit: {


### PR DESCRIPTION
**Fix 19-api-v3/01-api-directory.ts:**

In commit `29a8e6aa` (“SDX subsystems, services, runtime groups and connections (#1313)”, 2026-03-25), `e2e/cypress/support/prep-commands.ts` was updated so the org created in `buildOrgGatewayDatasetAndProduct` uses member tags instead of an empty list:

- Before: `tags: []`
- After: `tags: ['member_class:MIN', `member_id:${orgId}`]`

The same commit updated the expected nested `organization.tags` in the prep command’s own dataset GET assertion. `01-api-directory.ts` was left expecting `organization.tags: []`, so it started failing once the shared workingData.org included those tags (they’re stored on the org and come back on any response that embeds `organization`).

The change that made the tests need updating is that prep-commands change; I updated `01-api-directory.ts` to align with it.

**Fix 14-org-assignment:**

When selecting `organization-admin` group to join in Keycloak, `system-owner` group now shows up as well. Changed cypress to only check the first checkbox it finds in the `setUserToOrganization` function, which will always be the `organization-admin` group. 

---
🚀 Feature branch deployment: https://api-services-portal-feature-cypress-fixes.apps.silver.devops.gov.bc.ca