### PR TITLE
Add optional unique publicBodyId reference to Organization

### DIFF
--- a/.github/workflows/scripts/feeder-init/organization-unit.yaml
+++ b/.github/workflows/scripts/feeder-init/organization-unit.yaml
@@ -7,7 +7,7 @@ record:
   title: 'Ministry of Citizens Services'
   tags: []
   description: ''
-  extSource: ''
+  extSource: 'ckan'
   extRecordHash: ''
   orgUnits:
     - id: 319b3297-846d-4b97-8095-ceb3ec505fb8
@@ -16,5 +16,5 @@ record:
       title: 'DataBC'
       tags: []
       description: ''
-      extSource: ''
+      extSource: 'ckan'
       extRecordHash: ''

--- a/docs/postgres/MIGRATION.md
+++ b/docs/postgres/MIGRATION.md
@@ -3,3 +3,19 @@
 ```
 alter table public."Environment" add column approval boolean NOT NULL default false;  
 ```
+
+## Organization.publicBodyId
+
+Optional reference from an Organization to a Public Body in the authoritative
+data registry (FOIPPA).  The column is nullable so that Organizations which
+are not Public Bodies can leave it unset, but every non-null value must be
+unique across the table.  The partial unique index excludes NULLs so multiple
+rows may coexist without a `publicBodyId`.
+
+```
+alter table public."Organization" add column "publicBodyId" text;
+
+create unique index organization_publicbodyid_unique
+    on public."Organization" ("publicBodyId")
+    where "publicBodyId" is not null;
+```

--- a/e2e/cypress/support/prep-commands.ts
+++ b/e2e/cypress/support/prep-commands.ts
@@ -22,11 +22,13 @@ Cypress.Commands.add('buildOrgGatewayDatasetAndProduct', (): Cypress.Chainable<a
           description: 'Some good description about how we manage our toys',
           tags: [],
           extForeignKey: `division-of-toys-${orgId}`,
-          extSource: 'internal',
+          // "ckan" so the org is eligible for gateway assignment in the UI
+          // (Add Organization filters on extSource === "ckan").
+          extSource: 'ckan',
           extRecordHash: '',
         },
       ],
-      extSource: 'internal',
+      extSource: 'ckan',
       extRecordHash: '',
     }
 

--- a/e2e/cypress/tests/21-notifications/01-namespace-assignment-notification.ts
+++ b/e2e/cypress/tests/21-notifications/01-namespace-assignment-notification.ts
@@ -53,11 +53,12 @@ describe('Notification Service - Namespace Assignment Emails', () => {
             description: 'Division for testing notification emails',
             tags: [],
             extForeignKey: `division-of-testing-${datasetId}`,
-            extSource: 'internal',
+            // Must match catalogue-sourced filter on gateway org assignment UI.
+            extSource: 'ckan',
             extRecordHash: '',
           },
         ],
-        extSource: 'internal',
+        extSource: 'ckan',
         extRecordHash: '',
       }
 

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -39,6 +39,7 @@
         "@types/mochawesome": "^6.2.0",
         "@types/node": "^16.0.0",
         "@types/request": "^2.48.7",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
         "@typescript-eslint/parser": "^4.28.1",
         "cypress": "^13.17.0",
@@ -2567,6 +2568,13 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",

--- a/local/db/keystone-init.sql
+++ b/local/db/keystone-init.sql
@@ -867,6 +867,7 @@ CREATE TABLE public."Organization" (
     title text NOT NULL,
     tags text NOT NULL,
     description text,
+    "publicBodyId" text,
     "extSource" text NOT NULL,
     "extForeignKey" text NOT NULL,
     "extRecordHash" text NOT NULL
@@ -1616,6 +1617,19 @@ ALTER TABLE ONLY public."Legal"
 
 ALTER TABLE ONLY public."Organization"
     ADD CONSTRAINT organization_extforeignkey_unique UNIQUE ("extForeignKey");
+
+
+--
+-- Name: organization_publicbodyid_unique; Type: INDEX; Schema: public; Owner: keystonejsuser
+--
+-- Partial unique index: a publicBodyId, when set, must be unique across all
+-- Organizations.  NULL values are excluded so that multiple Organizations
+-- may omit the public-body reference entirely.
+--
+
+CREATE UNIQUE INDEX organization_publicbodyid_unique
+    ON public."Organization" ("publicBodyId")
+    WHERE "publicBodyId" IS NOT NULL;
 
 
 --

--- a/local/feeder-init/organization-unit.yaml
+++ b/local/feeder-init/organization-unit.yaml
@@ -7,7 +7,7 @@ record:
   title: 'Ministry of Health'
   tags: []
   description: 'The Ministry of Health has overall responsibility for ensuring that quality, appropriate, cost effective and timely health services are available for all British Columbians.'
-  extSource: ''
+  extSource: 'ckan'
   extRecordHash: ''
   namespace: newplatform
   orgUnits:
@@ -17,7 +17,7 @@ record:
       title: 'Planning and Innovation Division'
       tags: []
       description: ''
-      extSource: ''
+      extSource: 'ckan'
       extRecordHash: ''
     - id: 319b3297-846d-4b97-8095-ceb3ec505fdf
       name: public-health
@@ -25,5 +25,5 @@ record:
       title: 'Public Health'
       tags: []
       description: ''
-      extSource: ''
+      extSource: 'ckan'
       extRecordHash: ''

--- a/src/authz/graphql-whitelist/httplocalhost4180managernamespaces-1e1ba6.gql
+++ b/src/authz/graphql-whitelist/httplocalhost4180managernamespaces-1e1ba6.gql
@@ -1,6 +1,6 @@
 
   query ListOrganizations {
-    allOrganizations(sortBy: title_ASC) {
+    allOrganizations(where: { extSource: "ckan" }, sortBy: title_ASC) {
       name
       title
     }

--- a/src/authz/graphql-whitelist/httplocalhost4180managernamespaces-baaf73.gql
+++ b/src/authz/graphql-whitelist/httplocalhost4180managernamespaces-baaf73.gql
@@ -1,6 +1,6 @@
 
   query ListOrganizationUnits($org: String!) {
-    allOrganizations(where: { name: $org }) {
+    allOrganizations(where: { name: $org, extSource: "ckan" }) {
       orgUnits {
         name
         title

--- a/src/batch/data-rules.js
+++ b/src/batch/data-rules.js
@@ -8,6 +8,7 @@ const metadata = {
       'title',
       'tags',
       'description',
+      'publicBodyId',
       'orgUnits',
       'extSource',
       'extRecordHash',

--- a/src/batch/data-rules.js
+++ b/src/batch/data-rules.js
@@ -19,6 +19,7 @@ const metadata = {
         name: 'connectExclusiveListCreate',
         list: 'OrganizationUnit',
         syncFirst: true,
+        refKey: 'extForeignKey',
       },
     },
   },

--- a/src/controllers/sdx/v1/CatalogController.ts
+++ b/src/controllers/sdx/v1/CatalogController.ts
@@ -54,6 +54,7 @@ export class CatalogController extends Controller {
         name: o.name,
         title: o.title,
         description: o.description,
+        publicBodyId: o.publicBodyId,
         member: getOrganizationMemberDetails(o.tags),
       }))
       .filter((o) => o.member !== undefined)

--- a/src/controllers/v2/OrganizationController.ts
+++ b/src/controllers/v2/OrganizationController.ts
@@ -37,7 +37,11 @@ import {
   GroupMembership,
   OrgNamespace,
 } from '../../services/org-groups/types';
-import { getOrganizations, getOrganizationUnit } from '../../services/keystone';
+import {
+  getOrganization,
+  getOrganizations,
+  getOrganizationUnit,
+} from '../../services/keystone';
 import { getActivity } from '../../services/keystone/activity';
 import { Activity } from './types';
 import { isParent } from '../../services/org-groups/group-converter-utils';
@@ -161,6 +165,16 @@ export class OrganizationController extends Controller {
   }
 
   /**
+   * Assign a Namespace to an Organization Unit.
+   *
+   * Only Organizations sourced from the BC Data Catalogue
+   * (`extSource: "ckan"`) may be assigned to a Namespace.  Organizations
+   * sourced from SDX or created as "custom" entries are intentionally
+   * rejected so that namespace-to-organization mappings stay aligned
+   * with the authoritative public-body data registry.  This mirrors the
+   * filter applied to the _Add Organization_ dropdown in the UI so
+   * direct API callers cannot bypass it.
+   *
    * > `Required Scope:` Namespace.Assign
    */
   @Put('{org}/{orgUnit}/namespaces/{ns}')
@@ -179,6 +193,14 @@ export class OrganizationController extends Controller {
       true,
       'org',
       'Invalid Organization'
+    );
+
+    const parentOrg = await getOrganization(ctx, org);
+    assertEqual(
+      parentOrg.extSource === 'ckan',
+      true,
+      'org',
+      'Only ckan-sourced Organizations may be assigned to a namespace'
     );
 
     const prodEnv = await getGwaProductEnvironment(ctx, false);

--- a/src/controllers/v2/openapi.yaml
+++ b/src/controllers/v2/openapi.yaml
@@ -1558,7 +1558,7 @@ paths:
                                 required:
                                     - result
                                 type: object
-            description: '> `Required Scope:` Namespace.Assign'
+            description: "Assign a Namespace to an Organization Unit.\n\nOnly Organizations sourced from the BC Data Catalogue\n(`extSource: \"ckan\"`) may be assigned to a Namespace.  Organizations\nsourced from SDX or created as \"custom\" entries are intentionally\nrejected so that namespace-to-organization mappings stay aligned\nwith the authoritative public-body data registry.  This mirrors the\nfilter applied to the _Add Organization_ dropdown in the UI so\ndirect API callers cannot bypass it.\n\n> `Required Scope:` Namespace.Assign"
             tags:
                 - Organizations
             security:

--- a/src/controllers/v2/types.ts
+++ b/src/controllers/v2/types.ts
@@ -17,6 +17,7 @@ export interface Organization {
   sector?: string;
   title?: string;
   description?: string;
+  publicBodyId?: string;
   extSource?: string;
   extRecordHash?: string;
   tags?: string[];

--- a/src/controllers/v3/OrganizationController.ts
+++ b/src/controllers/v3/OrganizationController.ts
@@ -39,7 +39,11 @@ import {
   GroupMembership,
   OrgNamespace,
 } from '../../services/org-groups/types';
-import { getOrganizations, getOrganizationUnit } from '../../services/keystone';
+import {
+  getOrganization,
+  getOrganizations,
+  getOrganizationUnit,
+} from '../../services/keystone';
 import { getActivity } from '../../services/keystone/activity';
 import { Activity, Organization } from './types';
 import { isParent } from '../../services/org-groups/group-converter-utils';
@@ -203,6 +207,16 @@ export class OrganizationController extends Controller {
   }
 
   /**
+   * Assign a Gateway to an Organization Unit.
+   *
+   * Only Organizations sourced from the BC Data Catalogue
+   * (`extSource: "ckan"`) may be assigned to a Gateway.  Organizations
+   * sourced from SDX or created as "custom" entries are intentionally
+   * rejected so that gateway-to-organization mappings stay aligned with
+   * the authoritative public-body data registry.  This mirrors the
+   * filter applied to the _Add Organization_ dropdown in the UI so
+   * direct API callers cannot bypass it.
+   *
    * > `Required Scope:` Gateway.Assign
    */
   @Put('{org}/{orgUnit}/gateways/{gatewayId}')
@@ -222,6 +236,14 @@ export class OrganizationController extends Controller {
       true,
       'org',
       'Invalid Organization'
+    );
+
+    const parentOrg = await getOrganization(ctx, org);
+    assertEqual(
+      parentOrg.extSource === 'ckan',
+      true,
+      'org',
+      'Only ckan-sourced Organizations may be assigned to a gateway'
     );
 
     const prodEnv = await getGwaProductEnvironment(ctx, false);

--- a/src/controllers/v3/OrganizationController.ts
+++ b/src/controllers/v3/OrganizationController.ts
@@ -70,7 +70,14 @@ export class OrganizationController extends Controller {
   }
 
   /**
-   * Create Organization
+   * Create or update Organizations.
+   *
+   * The body may optionally carry a `publicBodyId` to link the
+   * Organization to a Public Body from the authoritative data registry
+   * (FOIPPA).  This field is unique across all Organizations; multiple
+   * Organizations may omit the value entirely, but a given
+   * `publicBodyId` MUST not be reused across Organizations.
+   *
    * > `Required Scope:` GroupAccess.Manage
    *
    * @summary Create Organizations

--- a/src/controllers/v3/openapi.yaml
+++ b/src/controllers/v3/openapi.yaml
@@ -490,6 +490,8 @@ components:
                     type: string
                 description:
                     type: string
+                publicBodyId:
+                    type: string
                 extSource:
                     type: string
                 extRecordHash:
@@ -1439,7 +1441,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/BatchResult'
-            description: "Create Organization\n> `Required Scope:` GroupAccess.Manage"
+            description: "Create or update Organizations.\n\nThe body may optionally carry a `publicBodyId` to link the\nOrganization to a Public Body from the authoritative data registry\n(FOIPPA).  This field is unique across all Organizations; multiple\nOrganizations may omit the value entirely, but a given\n`publicBodyId` MUST not be reused across Organizations.\n\n> `Required Scope:` GroupAccess.Manage"
             summary: 'Create Organizations'
             tags:
                 - Organizations

--- a/src/controllers/v3/openapi.yaml
+++ b/src/controllers/v3/openapi.yaml
@@ -1593,7 +1593,7 @@ paths:
                                 required:
                                     - result
                                 type: object
-            description: '> `Required Scope:` Gateway.Assign'
+            description: "Assign a Gateway to an Organization Unit.\n\nOnly Organizations sourced from the BC Data Catalogue\n(`extSource: \"ckan\"`) may be assigned to a Gateway.  Organizations\nsourced from SDX or created as \"custom\" entries are intentionally\nrejected so that gateway-to-organization mappings stay aligned with\nthe authoritative public-body data registry.  This mirrors the\nfilter applied to the _Add Organization_ dropdown in the UI so\ndirect API callers cannot bypass it.\n\n> `Required Scope:` Gateway.Assign"
             tags:
                 - Organizations
             security:

--- a/src/controllers/v3/routes.ts
+++ b/src/controllers/v3/routes.ts
@@ -310,6 +310,7 @@ const models: TsoaRoute.Models = {
             "sector": {"dataType":"string"},
             "title": {"dataType":"string"},
             "description": {"dataType":"string"},
+            "publicBodyId": {"dataType":"string"},
             "extSource": {"dataType":"string"},
             "extRecordHash": {"dataType":"string"},
             "tags": {"dataType":"array","array":{"dataType":"string"}},

--- a/src/controllers/v3/types.ts
+++ b/src/controllers/v3/types.ts
@@ -17,6 +17,7 @@ export interface Organization {
   sector?: string;
   title?: string;
   description?: string;
+  publicBodyId?: string;
   extSource?: string;
   extRecordHash?: string;
   tags?: string[];

--- a/src/lists/Organization.js
+++ b/src/lists/Organization.js
@@ -33,6 +33,15 @@ module.exports = {
         type: Text,
         isRequired: false,
     },
+    // Optional reference to a Public Body from the authoritative
+    // data registry (FOIPPA).  When set it MUST be unique across all
+    // Organizations, but multiple Organizations may have a NULL value
+    // (i.e. not all Organizations are Public Bodies).
+    publicBodyId: {
+        type: Text,
+        isRequired: false,
+        isUnique: true,
+    },
     orgUnits: { type: Relationship, ref: "OrganizationUnit", many: true }
   },
   access: EnforcementPoint,

--- a/src/nextapp/components/new-organization-form/new-organization-form.tsx
+++ b/src/nextapp/components/new-organization-form/new-organization-form.tsx
@@ -160,9 +160,14 @@ const NewOrganizationForm: React.FC = () => {
 
 export default NewOrganizationForm;
 
+// Only CKAN-sourced organizations (those from the authoritative
+// BC Data Catalogue) can be assigned to a gateway.  Organizations
+// sourced from SDX or created as "custom" entries are intentionally
+// excluded so that gateway-to-organization mappings stay aligned with
+// the public-body data registry.
 const query = gql`
   query ListOrganizations {
-    allOrganizations(sortBy: title_ASC) {
+    allOrganizations(where: { extSource: "ckan" }, sortBy: title_ASC) {
       name
       title
     }
@@ -171,7 +176,7 @@ const query = gql`
 
 const queryUnits = gql`
   query ListOrganizationUnits($org: String!) {
-    allOrganizations(where: { name: $org }) {
+    allOrganizations(where: { name: $org, extSource: "ckan" }) {
       orgUnits {
         name
         title

--- a/src/nextapp/shared/types/query.types.ts
+++ b/src/nextapp/shared/types/query.types.ts
@@ -5901,6 +5901,7 @@ export type Organization = {
   title?: Maybe<Scalars['String']>;
   tags?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
+  publicBodyId?: Maybe<Scalars['String']>;
   orgUnits: Array<OrganizationUnit>;
   _orgUnitsMeta?: Maybe<_QueryMeta>;
   extSource?: Maybe<Scalars['String']>;

--- a/src/services/batch/types.ts
+++ b/src/services/batch/types.ts
@@ -17,6 +17,7 @@ export interface Organization {
   sector?: string;
   title?: string;
   description?: string;
+  publicBodyId?: string;
   extSource?: string;
   extRecordHash?: string;
   tags?: string[];

--- a/src/services/keystone/index.ts
+++ b/src/services/keystone/index.ts
@@ -78,7 +78,11 @@ export {
   calculateStats,
 } from './metrics';
 
-export { getOrganizations, getOrganizationUnit } from './organization';
+export {
+  getOrganization,
+  getOrganizations,
+  getOrganizationUnit,
+} from './organization';
 
 export { getConsumerLabels } from './labels';
 

--- a/src/services/keystone/organization.ts
+++ b/src/services/keystone/organization.ts
@@ -22,6 +22,8 @@ export async function getOrganizations(context: any): Promise<Organization[]> {
                         title
                         tags
                         description
+                        publicBodyId
+                        extSource
                         orgUnits {
                           name
                           title
@@ -49,6 +51,8 @@ export async function getOrganization(
                         title
                         description
                         tags
+                        publicBodyId
+                        extSource
                     }
                 }`,
     variables: { name },

--- a/src/services/keystone/types.ts
+++ b/src/services/keystone/types.ts
@@ -6082,6 +6082,7 @@ export type Organization = {
   title?: Maybe<Scalars['String']>;
   tags?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
+  publicBodyId?: Maybe<Scalars['String']>;
   orgUnits: Array<OrganizationUnit>;
   _orgUnitsMeta?: Maybe<_QueryMeta>;
   extSource?: Maybe<Scalars['String']>;
@@ -6117,6 +6118,7 @@ export type OrganizationCreateInput = {
   title?: Maybe<Scalars['String']>;
   tags?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
+  publicBodyId?: Maybe<Scalars['String']>;
   orgUnits?: Maybe<OrganizationUnitRelateToManyInput>;
   extSource?: Maybe<Scalars['String']>;
   extForeignKey?: Maybe<Scalars['String']>;
@@ -6371,6 +6373,7 @@ export type OrganizationUpdateInput = {
   title?: Maybe<Scalars['String']>;
   tags?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
+  publicBodyId?: Maybe<Scalars['String']>;
   orgUnits?: Maybe<OrganizationUnitRelateToManyInput>;
   extSource?: Maybe<Scalars['String']>;
   extForeignKey?: Maybe<Scalars['String']>;

--- a/src/test/services/keystone/organization.test.ts
+++ b/src/test/services/keystone/organization.test.ts
@@ -1,0 +1,110 @@
+import {
+  getOrganization,
+  getOrganizations,
+  getOrganizationMemberDetails,
+  parseOrganizationMemberDetails,
+} from '../../../services/keystone/organization';
+
+const orgs = [
+  {
+    name: 'ministry-of-health',
+    title: 'Ministry of Health',
+    description: 'Health stuff',
+    tags: JSON.stringify(['member_class:MIN', 'member_id:CITZ']),
+    publicBodyId: 'PB-MOH-001',
+    extSource: 'ckan',
+    orgUnits: [
+      {
+        name: 'planning-and-innovation-division',
+        title: 'Planning and Innovation',
+      },
+    ],
+  },
+  {
+    name: 'ministry-of-citizens-services',
+    title: 'Ministry of Citizens Services',
+    description: 'Custom org without a public body reference',
+    tags: JSON.stringify([]),
+    publicBodyId: null,
+    extSource: 'sdx',
+    orgUnits: [],
+  },
+];
+
+function mockContext(): any {
+  return {
+    executeGraphQL: jest.fn(({ query, variables }: any) => {
+      if (query.indexOf('GetOrganizations') < 0) {
+        return { errors: [{ message: 'Unexpected query' }] };
+      }
+      if (variables && 'name' in variables) {
+        return {
+          data: {
+            allOrganizations: orgs.filter((o) => o.name === variables.name),
+          },
+        };
+      }
+      return { data: { allOrganizations: orgs } };
+    }),
+  };
+}
+
+describe('KeystoneJS', function () {
+  describe('test getOrganizations', function () {
+    it('asks the GraphQL API for publicBodyId and extSource', async function () {
+      const ctx = mockContext();
+      await getOrganizations(ctx);
+      expect(ctx.executeGraphQL.mock.calls[0][0].query).toContain(
+        'publicBodyId'
+      );
+      expect(ctx.executeGraphQL.mock.calls[0][0].query).toContain('extSource');
+    });
+
+    it('returns the publicBodyId value alongside other Organization fields', async function () {
+      const result = await getOrganizations(mockContext());
+      expect(result).toHaveLength(2);
+      expect(result[0].publicBodyId).toBe('PB-MOH-001');
+      expect(result[0].extSource).toBe('ckan');
+      expect(result[1].publicBodyId).toBeNull();
+      expect(result[1].extSource).toBe('sdx');
+    });
+  });
+
+  describe('test getOrganization', function () {
+    it('asks the GraphQL API for publicBodyId and extSource', async function () {
+      const ctx = mockContext();
+      await getOrganization(ctx, 'ministry-of-health');
+      expect(ctx.executeGraphQL.mock.calls[0][0].query).toContain(
+        'publicBodyId'
+      );
+      expect(ctx.executeGraphQL.mock.calls[0][0].query).toContain('extSource');
+    });
+
+    it('returns the publicBodyId for the named Organization', async function () {
+      const result = await getOrganization(
+        mockContext(),
+        'ministry-of-health'
+      );
+      expect(result.publicBodyId).toBe('PB-MOH-001');
+    });
+  });
+
+  describe('test getOrganizationMemberDetails', function () {
+    it('parses member tags', function () {
+      const member = getOrganizationMemberDetails(
+        JSON.stringify(['member_class:MIN', 'member_id:CITZ'])
+      );
+      expect(member).toEqual({ memberClass: 'MIN', memberId: 'CITZ' });
+    });
+
+    it('returns undefined when no member tags are present', function () {
+      expect(getOrganizationMemberDetails(JSON.stringify([]))).toBeUndefined();
+    });
+
+    it('throws via parseOrganizationMemberDetails when member info is missing', function () {
+      expect(() =>
+        parseOrganizationMemberDetails(JSON.stringify([]))
+      ).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
# Local testing

## Step 1 - Get an admin token

```bash
export TOKEN=$(curl -s -X POST \
  http://keycloak.localtest.me:9081/auth/realms/master/protocol/openid-connect/token \
  -d "grant_type=password&client_id=admin-cli&username=janis@idir&password=awsummer" \
  | jq -r .access_token)
echo "${TOKEN:0:40}..."
```

Expect a non-empty token prefix.

## Step 2 - Create an Organization with a `publicBodyId`

```bash
curl -X PUT http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ca.bc.gov \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name":"min-of-health-pb",
    "title":"Ministry of Health (PB Test)",
    "tags":["member_class:MIN","member_id:HLTH"],
    "description":"Test org for publicBodyId",
    "extSource":"ckan",
    "extRecordHash":"",
    "publicBodyId":"PB-MOH-001"
  }'
```

Expect: `{"status":200,"result":"created","id":<int>,"childResults":[]}`.

## Step 3 - Prove the unique constraint blocks duplicates

```bash
curl -X PUT http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ca.bc.gov \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name":"duplicate-pb",
    "title":"Duplicate Public Body",
    "tags":["member_class:MIN","member_id:HLTH2"],
    "extSource":"ckan",
    "extRecordHash":"",
    "publicBodyId":"PB-MOH-001"
  }'
```

Expect: `400 create-failed` whose `reason` mentions `organization_publicbodyid_unique` (duplicate key value violates unique constraint).

## Step 4 - Prove multiple NULL `publicBodyId`s are allowed

```bash
curl -X PUT http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ca.bc.gov \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"no-pb-a","title":"No PB A","tags":[],"extSource":"ckan","extRecordHash":""}'

curl -X PUT http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ca.bc.gov \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"no-pb-b","title":"No PB B","tags":[],"extSource":"ckan","extRecordHash":""}'
```

Both should return `200 created`. This is the "MAY have a reference" half of the acceptance criteria - multiple Organizations may omit `publicBodyId` simultaneously.

## Step 5 - Update an existing Org's `publicBodyId`

The v3 controller looks up the existing row by `extForeignKey === body.name`. The first PUT for `min-of-health-pb` stored `extForeignKey = "min-of-health-pb"`, so resending the same `name` triggers an update branch:

```bash
curl -X PUT http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ca.bc.gov \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name":"min-of-health-pb",
    "title":"Ministry of Health (PB Test)",
    "tags":["member_class:MIN","member_id:HLTH"],
    "extSource":"ckan",
    "extRecordHash":"",
    "publicBodyId":"PB-MOH-002"
  }'
```

Expect: `{"status":200,"result":"updated",...}` (note `updated`, not `created`). Verify in Postgres:

```bash
docker exec -i kong-db psql -U keystonejsuser -d keystonejs \
  -c 'SELECT name, "publicBodyId" FROM public."Organization" WHERE name = '\''min-of-health-pb'\'';'
```

Expect a single row with `publicBodyId = PB-MOH-002`.

## Step 6 - Verify the GET exposes `publicBodyId`

The `/catalog/organizations` endpoint filters Organizations down to those
that have valid SDX member tags (`member_class:<X>` and `member_id:<Y>`).
Because we PUT `min-of-health-pb` with those tags in steps 2 and 5, it
should appear here:

```bash
curl -s http://oauth2proxy.localtest.me:4180/ds/api/sdx/v1/catalog/organizations \
  -H "Authorization: Bearer $TOKEN" | jq
```

Expect a response containing at least:

```json
{
  "name": "min-of-health-pb",
  "title": "Ministry of Health (PB Test)",
  "description": "Test org for publicBodyId",
  "publicBodyId": "PB-MOH-002",
  "member": { "memberClass": "MIN", "memberId": "HLTH" }
}
```

Notes:

- Orgs without `publicBodyId` (e.g. `no-pb-a`, `no-pb-b`) will *not* appear
  here because they don't carry member tags - that's the catalog endpoint's
  pre-existing filter, not something `publicBodyId` changes.
- Orgs that *do* have member tags but no `publicBodyId` should appear
  without the `publicBodyId` key - the `removeEmpty` helper strips null
  fields from the response.

If you want to verify *all* rows regardless of the catalog's member filter
(useful for confirming that orgs created with an empty `tags` array still
persist their `publicBodyId`), drop into Postgres directly:

```bash
docker exec -i kong-db psql -U keystonejsuser -d keystonejs <<'SQL'
SELECT name, "publicBodyId", "extSource", "extForeignKey", tags
FROM public."Organization"
ORDER BY id DESC LIMIT 10;
SQL
```

## Step 7 - Verify the UI filter

The *Add Organization to gateway* form should only show organizations whose
`extSource = "ckan"`. Everything we created above uses `extSource: "ckan"`,
so create one more with a different source to prove the filter works:

```bash
curl -X PUT http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ca.bc.gov \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"sdx-only-org","title":"SDX Only","tags":[],"extSource":"sdx","extRecordHash":""}'
```

Then in a browser:

1. Open <http://oauth2proxy.localtest.me:4180/> and sign in as
   `janis@idir` / `awsummer`.
2. Navigate to a gateway and open *Add Organization*.
3. The dropdown should list `min-of-health-pb`, `no-pb-a`, `no-pb-b` (all
   `extSource: "ckan"`).
4. The dropdown should **not** include `sdx-only-org` even though it exists
   in the database.

## Step 8 - Run the unit test

`src/test/services/keystone/organization.test.ts` covers `getOrganizations`,
`getOrganization`, `getOrganizationMemberDetails`, and
`parseOrganizationMemberDetails`, including the new `publicBodyId` field.

```bash
cd src
npx jest \
  --config ./jest.config.js \
  --testMatch '**/?(*.)+(test).{js,jsx,ts,tsx}' \
  --testPathPattern 'organization'
```

Expect all assertions to pass, including:

- `getOrganizations` asks the GraphQL API for `publicBodyId` and `extSource`.
- `getOrganizations` returns `publicBodyId` alongside other fields, including
  `null` values for orgs without a public-body reference.
- `getOrganization` asks for and returns `publicBodyId` for a named org.
- `getOrganizationMemberDetails` / `parseOrganizationMemberDetails` parse and
  validate SDX member tags.

## Step 9 - Verify the API guard blocks non-`ckan` Organizations from gateway assignment

The UI already filters the _Add Organization_ dropdown to `extSource: "ckan"`,
but a direct API caller of `PUT /organizations/{org}/{orgUnit}/gateways/{gatewayId}`
could previously bypass it. This step proves the new server-side guard on both
the v3 and v2 endpoints.

**Pre-requisite:** Steps 1–8 must have been completed so that `$TOKEN` is still
set. If you opened a new terminal, re-run Step 1 first.

**Why we use `ministry-of-health` / `planning-and-innovation-division` here:**
The Keycloak realm seed (`local/keycloak/master-realm.json`) only pre-registers
a fixed set of UMA resources — `org/ca.bc.gov`, `org/ministry-of-health`, and
`org/planning-and-innovation-division`. Newly created org units (like the
`moh-unit` / `sdx-only-unit` from earlier steps) are not registered as Keycloak
UMA resources, so any token gets a 403 before it even reaches our application
guard. Using the pre-registered `planning-and-innovation-division` unit lets us
test that the guard fires correctly.

---

### 9a — Create a throwaway gateway and export its ID

Use the `gwa` CLI to create the gateway:

```bash
gwa login
# Follow the browser prompts to authenticate as janis@idir / awsummer

gwa gateway create
# When prompted for a display name, enter: throwaway
# Note the printed Gateway ID, e.g. "Gateway ID: gw-55f72"
```

Export the gateway ID and the `gwa-cli` token (which carries the UMA
permissions that were seeded for `planning-and-innovation-division`):

```bash
export GWA_TOKEN=$(gwa config get api_key)

export GW=$(curl -s http://oauth2proxy.localtest.me:4180/ds/api/v3/gateways \
  -H "Authorization: Bearer $GWA_TOKEN" | jq -r '.[0].gatewayId')
echo "$GW"
```

Expect a non-empty gateway ID such as `gw-55f72`.

---

### 9b — Negative case (v3): temporarily set `ministry-of-health` to `sdx`-sourced

The `planning-and-innovation-division` unit sits under `ministry-of-health`.
To prove the guard rejects a non-ckan parent org, flip its `extSource` to `sdx`
directly in Postgres, make the API call (expect 400), then revert.

```bash
# Flip extSource to sdx
docker exec -i kong-db psql -U keystonejsuser -d keystonejs \
  -c 'UPDATE public."Organization" SET "extSource"='"'"'sdx'"'"' WHERE name='"'"'ministry-of-health'"'"';'

# Attempt the assignment — expect 422
curl -i -X PUT \
  "http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ministry-of-health/planning-and-innovation-division/gateways/$GW" \
  -H "Authorization: Bearer $GWA_TOKEN"

# Revert extSource back to ckan immediately
docker exec -i kong-db psql -U keystonejsuser -d keystonejs \
  -c 'UPDATE public."Organization" SET "extSource"='"'"'ckan'"'"' WHERE name='"'"'ministry-of-health'"'"';'
```

Expected response for the PUT: `HTTP/1.1 422` with a JSON body where
`fields.org.message` is:

```
"Only ckan-sourced Organizations may be assigned to a gateway"
```

(TSOA maps `ValidateError` to HTTP 422)

Before this PR the same call would have returned `200 namespace-assigned`.

---

### 9c — Positive case (v3): ckan-sourced org passes the guard

With `ministry-of-health` now reverted to `ckan`:

```bash
curl -i -X PUT \
  "http://oauth2proxy.localtest.me:4180/ds/api/v3/organizations/ministry-of-health/planning-and-innovation-division/gateways/$GW" \
  -H "Authorization: Bearer $GWA_TOKEN"
```

The response will **not** contain `"Only ckan-sourced Organizations may be
assigned to a gateway"` — our guard lets the `ckan` org through. In a fully
provisioned environment you would see `200 namespace-assigned`.

In the local dev environment the call may fail further inside
`GroupAccessService.assignNamespace` with a `422` about a missing Keycloak
policy (`group-system-owner-...-policy`). That is a pre-existing Keycloak seed
gap unrelated to this PR — the important thing is the guard message is absent,
confirming `ckan`-sourced orgs are not blocked by our change.

---

### 9d — Same guard on the v2 sibling endpoint

The lockdown is also applied to `PUT /organizations/{org}/{orgUnit}/namespaces/{ns}` in v2.

```bash
# v2 negative: flip to sdx, test, revert
docker exec -i kong-db psql -U keystonejsuser -d keystonejs \
  -c 'UPDATE public."Organization" SET "extSource"='"'"'sdx'"'"' WHERE name='"'"'ministry-of-health'"'"';'

curl -i -X PUT \
  "http://oauth2proxy.localtest.me:4180/ds/api/v2/organizations/ministry-of-health/planning-and-innovation-division/namespaces/$GW" \
  -H "Authorization: Bearer $GWA_TOKEN"

docker exec -i kong-db psql -U keystonejsuser -d keystonejs \
  -c 'UPDATE public."Organization" SET "extSource"='"'"'ckan'"'"' WHERE name='"'"'ministry-of-health'"'"';'
```

Expect the PUT: `HTTP/1.1 422` with `fields.org.message` =
`"Only ckan-sourced Organizations may be assigned to a namespace"`.

```bash
# v2 positive
curl -i -X PUT \
  "http://oauth2proxy.localtest.me:4180/ds/api/v2/organizations/ministry-of-health/planning-and-innovation-division/namespaces/$GW" \
  -H "Authorization: Bearer $GWA_TOKEN"
```

The response will **not** contain `"Only ckan-sourced Organizations may be
assigned to a namespace"` — the guard passes the `ckan` org through. Same
caveat as 9c: the local dev Keycloak may fail further downstream, but the
guard is not the blocker.

---

### 9e — (Optional) Clean up the throwaway gateway

```bash
curl -X DELETE "http://oauth2proxy.localtest.me:4180/ds/api/v3/gateways/$GW" \
  -H "Authorization: Bearer $GWA_TOKEN"
```

---
🚀 Feature branch deployment: https://api-services-portal-feature-sdx-org-public-body.apps.silver.devops.gov.bc.ca

---
🚀 Feature branch deployment: https://api-services-portal-feature-sdx-org-public-body.apps.silver.devops.gov.bc.ca

---
🚀 Feature branch deployment: https://api-services-portal-feature-sdx-org-public-body.apps.silver.devops.gov.bc.ca