### PR TITLE
update GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/aps-cypress-e2e.yaml
+++ b/.github/workflows/aps-cypress-e2e.yaml
@@ -30,7 +30,7 @@ jobs:
           docker build -t gwa-api:e2e .
 
       - name: Checkout Portal
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -70,21 +70,21 @@ jobs:
 
       - name: Upload E2E Test Results HTML Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-html
           path: ${{ github.workspace }}/e2e/results/report
 
       - name: Upload E2E Test Results JSON Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-json
           path: ${{ github.workspace }}/e2e/results/bcgov-aps-e2e-report.json
 
       - name: Upload E2E Code Coverage Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code-coverage
           path: ${{ github.workspace }}/e2e/coverage
@@ -101,7 +101,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: always()
-        uses: sonarsource/sonarqube-scan-action@v3.1.0
+        uses: sonarsource/sonarqube-scan-action@v7
         with:
           args: >
             -Dsonar.organization=bcgov-oss
@@ -116,7 +116,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Upload Astra scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: astra-scan-results
           path: ${{ github.workspace }}/e2e/cypress/fixtures/state/scanResult.json
@@ -146,7 +146,7 @@ jobs:
 
       - name: Set up Python 3.9
         if: failure()
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           architecture: 'x64'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,9 +17,9 @@ jobs:
         working-directory: ./src/
     # the list of steps that the action will go through
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - run: yarn
-      - uses: chromaui/action@v1
+      - uses: chromaui/action@v16
         # options required to the GitHub chromatic action
         with:
           workingDir: ./src/

--- a/.github/workflows/ci-anchore-img-scan.yaml
+++ b/.github/workflows/ci-anchore-img-scan.yaml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag bcgov/api-services-portal:anchore-scan
       - name: Run the Anchore Scan
-        uses: anchore/scan-action@main
+        uses: anchore/scan-action@v7.4.0
         with:
           image: 'bcgov/api-services-portal:anchore-scan'
           fail-build: false
           output-file: 'anchore-results.sarif'
       - name: Upload Anchore Scan Results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: anchore-results.sarif

--- a/.github/workflows/ci-build-deploy.yaml
+++ b/.github/workflows/ci-build-deploy.yaml
@@ -15,46 +15,48 @@ jobs:
     steps:
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/bcgov/api-services-portal/api-services-portal
 
       - name: Set DEPLOY_ID which will deploy a custom deploy to 'dev' environment
         run: |
-          echo '::set-output name=DEPLOY_ID::${{ steps.docker_meta.outputs.version }}'
-          echo '::set-output name=APP_VERSION::${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}'
-          echo '::set-output name=APP_REVISION::${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}'
+          echo 'DEPLOY_ID=${{ steps.docker_meta.outputs.version }}' >> "$GITHUB_OUTPUT"
+          echo "APP_VERSION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> "$GITHUB_OUTPUT"
+          echo "APP_REVISION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}" >> "$GITHUB_OUTPUT"
         id: set-deploy-id
 
       - name: Get deploy ID
         run: echo "The DEPLOY_ID is ${{ steps.set-deploy-id.outputs.DEPLOY_ID }}"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
-        with:
-          version: '4.6'
+        run: |
+          curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz -o /tmp/openshift-client-linux.tar.gz
+          tar -xzf /tmp/openshift-client-linux.tar.gz -C /tmp oc
+          sudo install /tmp/oc /usr/local/bin/oc
+          oc version --client
 
       - name: Authenticate to silver and set context
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
-          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-
-          # Disables SSL cert checking. Use this if you don't have the certificate authority data.
-          insecure_skip_tls_verify: true
-
-          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+        env:
+          OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_SERVER }}
+          OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+          OPENSHIFT_NAMESPACE: ${{ env.OPENSHIFT_NAMESPACE }}
+        run: |
+          oc login "$OPENSHIFT_SERVER" --token="$OPENSHIFT_TOKEN" --insecure-skip-tls-verify=true
+          if [ -n "$OPENSHIFT_NAMESPACE" ]; then
+            oc project "$OPENSHIFT_NAMESPACE"
+          fi
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -63,10 +65,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -510,12 +512,15 @@ jobs:
 
       - name: Authenticate to Gold and set context
         if: github.ref == 'refs/heads/test'
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_GOLD_SERVER }}
-          openshift_token: ${{ secrets.OPENSHIFT_GOLD_TOKEN }}
-          insecure_skip_tls_verify: true
-          namespace: ${{ secrets.OPENSHIFT_GOLD_TEST_NAMESPACE }}
+        env:
+          OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_GOLD_SERVER }}
+          OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_GOLD_TOKEN }}
+          OPENSHIFT_NAMESPACE: ${{ secrets.OPENSHIFT_GOLD_TEST_NAMESPACE }}
+        run: |
+          oc login "$OPENSHIFT_SERVER" --token="$OPENSHIFT_TOKEN" --insecure-skip-tls-verify=true
+          if [ -n "$OPENSHIFT_NAMESPACE" ]; then
+            oc project "$OPENSHIFT_NAMESPACE"
+          fi
 
       - name: 'Restart Portal in Gold Test Namespace'
         if: github.ref == 'refs/heads/test'
@@ -525,7 +530,7 @@ jobs:
 
       - name: 'Create Pull Request for Release'
         if: github.ref == 'refs/heads/test'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const { repo, owner } = context.repo;

--- a/.github/workflows/ci-build-feeders.yaml
+++ b/.github/workflows/ci-build-feeders.yaml
@@ -15,46 +15,48 @@ jobs:
     steps:
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/bcgov/api-services-portal/data-feeder
 
       - name: Set DEPLOY_ID
         run: |
-          echo '::set-output name=DEPLOY_ID::${{ steps.docker_meta.outputs.version }}'
-          echo '::set-output name=APP_VERSION::${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}'
-          echo '::set-output name=APP_REVISION::${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}'
+          echo 'DEPLOY_ID=${{ steps.docker_meta.outputs.version }}' >> "$GITHUB_OUTPUT"
+          echo "APP_VERSION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> "$GITHUB_OUTPUT"
+          echo "APP_REVISION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}" >> "$GITHUB_OUTPUT"
         id: set-deploy-id
 
       - name: Get deploy ID
         run: echo "The DEPLOY_ID is ${{ steps.set-deploy-id.outputs.DEPLOY_ID }}"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
-        with:
-          version: '4.6'
+        run: |
+          curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz -o /tmp/openshift-client-linux.tar.gz
+          tar -xzf /tmp/openshift-client-linux.tar.gz -C /tmp oc
+          sudo install /tmp/oc /usr/local/bin/oc
+          oc version --client
 
       - name: Authenticate to silver and set context
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
-          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-
-          # Disables SSL cert checking. Use this if you don't have the certificate authority data.
-          insecure_skip_tls_verify: true
-
-          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+        env:
+          OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_SERVER }}
+          OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+          OPENSHIFT_NAMESPACE: ${{ env.OPENSHIFT_NAMESPACE }}
+        run: |
+          oc login "$OPENSHIFT_SERVER" --token="$OPENSHIFT_TOKEN" --insecure-skip-tls-verify=true
+          if [ -n "$OPENSHIFT_NAMESPACE" ]; then
+            oc project "$OPENSHIFT_NAMESPACE"
+          fi
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -63,10 +65,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -145,12 +147,15 @@ jobs:
 
       - name: Authenticate to Gold and set context
         if: github.ref == 'refs/heads/test'
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_GOLD_SERVER }}
-          openshift_token: ${{ secrets.OPENSHIFT_GOLD_TOKEN }}
-          insecure_skip_tls_verify: true
-          namespace: ${{ secrets.OPENSHIFT_GOLD_TEST_NAMESPACE }}
+        env:
+          OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_GOLD_SERVER }}
+          OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_GOLD_TOKEN }}
+          OPENSHIFT_NAMESPACE: ${{ secrets.OPENSHIFT_GOLD_TEST_NAMESPACE }}
+        run: |
+          oc login "$OPENSHIFT_SERVER" --token="$OPENSHIFT_TOKEN" --insecure-skip-tls-verify=true
+          if [ -n "$OPENSHIFT_NAMESPACE" ]; then
+            oc project "$OPENSHIFT_NAMESPACE"
+          fi
 
       - name: 'Restart Portal Feeder in Gold Test Namespace'
         if: github.ref == 'refs/heads/test'

--- a/.github/workflows/ci-build-only.yaml
+++ b/.github/workflows/ci-build-only.yaml
@@ -17,36 +17,36 @@ jobs:
     steps:
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/bcgov/api-services-portal/api-services-portal
 
       - name: Docker meta Feeder
         id: docker_meta_feeder
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/bcgov/api-services-portal/data-feeder
 
       - name: Set DEPLOY_ID which will deploy a custom deploy to 'dev' environment
         run: |
-          echo '::set-output name=DEPLOY_ID::${{ steps.docker_meta.outputs.version }}'
-          echo '::set-output name=APP_VERSION::${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}'
-          echo '::set-output name=APP_REVISION::${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}'
+          echo 'DEPLOY_ID=${{ steps.docker_meta.outputs.version }}' >> "$GITHUB_OUTPUT"
+          echo "APP_VERSION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> "$GITHUB_OUTPUT"
+          echo "APP_REVISION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}" >> "$GITHUB_OUTPUT"
         id: set-deploy-id
 
       - name: Get deploy ID
         run: echo "The DEPLOY_ID is ${{ steps.set-deploy-id.outputs.DEPLOY_ID }}"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -55,10 +55,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Feeder
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -72,7 +72,7 @@ jobs:
             APP_REVISION=${{ steps.set-deploy-id.outputs.APP_REVISION }}
 
       - name: Build Portal
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/ci-feat-sonar.yaml
+++ b/.github/workflows/ci-feat-sonar.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt update
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -48,7 +48,7 @@ jobs:
           docker compose down
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@v7
         with:
           args: >
             -Dsonar.organization=bcgov-sonarcloud

--- a/.github/workflows/ci-feat-url.yml
+++ b/.github/workflows/ci-feat-url.yml
@@ -8,12 +8,17 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Set KEBAB_CASE_BRANCH
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Convert github.head_ref to kebab case
-          kebab_case=$(echo "${{ github.head_ref }}" | sed 's/_/-/g; s/\//-/g')
-          echo "::set-output name=KEBAB_CASE_BRANCH::${kebab_case}"
+          kebab_case=$(echo "$HEAD_REF" | sed 's/_/-/g; s/\//-/g')
+          echo "KEBAB_CASE_BRANCH=${kebab_case}" >> "$GITHUB_OUTPUT"
         id: set-branch-id
 
       - name: Check the KEBAB_CASE_BRANCH output
@@ -21,8 +26,23 @@ jobs:
 
       - name: PR Description
         if: startsWith(github.head_ref, 'feature/') == true
-        uses: bcgov-nr/action-pr-description-add@v1.1.1
+        uses: actions/github-script@v8
+        env:
+          DEPLOYMENT_URL: https://api-services-portal-${{ steps.set-branch-id.outputs.KEBAB_CASE_BRANCH }}.apps.silver.devops.gov.bc.ca
         with:
-          add_markdown: |
-            ---
-            🚀 Feature branch deployment: https://api-services-portal-${{ steps.set-branch-id.outputs.KEBAB_CASE_BRANCH }}.apps.silver.devops.gov.bc.ca
+          script: |
+            const deploymentUrl = process.env.DEPLOYMENT_URL;
+            const markdown = ['---', `🚀 Feature branch deployment: ${deploymentUrl}`].join('\n');
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
+            const body = pull.body || '';
+
+            if (!body.includes(deploymentUrl)) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number,
+                body: body ? `${body}\n\n${markdown}` : markdown,
+              });
+            }

--- a/.github/workflows/ci-feat-url.yml
+++ b/.github/workflows/ci-feat-url.yml
@@ -26,23 +26,8 @@ jobs:
 
       - name: PR Description
         if: startsWith(github.head_ref, 'feature/') == true
-        uses: actions/github-script@v8
-        env:
-          DEPLOYMENT_URL: https://api-services-portal-${{ steps.set-branch-id.outputs.KEBAB_CASE_BRANCH }}.apps.silver.devops.gov.bc.ca
+        uses: bcgov-nr/action-pr-description-add@v2.0.1
         with:
-          script: |
-            const deploymentUrl = process.env.DEPLOYMENT_URL;
-            const markdown = ['---', `🚀 Feature branch deployment: ${deploymentUrl}`].join('\n');
-            const { owner, repo } = context.repo;
-            const pull_number = context.payload.pull_request.number;
-            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
-            const body = pull.body || '';
-
-            if (!body.includes(deploymentUrl)) {
-              await github.rest.pulls.update({
-                owner,
-                repo,
-                pull_number,
-                body: body ? `${body}\n\n${markdown}` : markdown,
-              });
-            }
+          add_markdown: |
+            ---
+            🚀 Feature branch deployment: https://api-services-portal-${{ steps.set-branch-id.outputs.KEBAB_CASE_BRANCH }}.apps.silver.devops.gov.bc.ca

--- a/.github/workflows/ci-remove.yaml
+++ b/.github/workflows/ci-remove.yaml
@@ -13,29 +13,31 @@ jobs:
         run: |
           echo "BRANCH = ${{ github.event.ref }}"
           export BRANCH="${{ github.event.ref }}"
-          echo "::set-output name=DEPLOY_ID::${BRANCH//\//-}"
+          echo "DEPLOY_ID=${BRANCH//\//-}" >> "$GITHUB_OUTPUT"
         id: set-deploy-id
 
       - name: Get deploy ID
         run: echo "The DEPLOY_ID is ${{ steps.set-deploy-id.outputs.DEPLOY_ID }}"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
-        with:
-          version: '4.6'
+        run: |
+          curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz -o /tmp/openshift-client-linux.tar.gz
+          tar -xzf /tmp/openshift-client-linux.tar.gz -C /tmp oc
+          sudo install /tmp/oc /usr/local/bin/oc
+          oc version --client
 
       - name: Authenticate and set context
-        uses: redhat-actions/oc-login@v1
-        with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
-          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-
-          # Disables SSL cert checking. Use this if you don't have the certificate authority data.
-          insecure_skip_tls_verify: true
-
-          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+        env:
+          OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_SERVER }}
+          OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+          OPENSHIFT_NAMESPACE: ${{ env.OPENSHIFT_NAMESPACE }}
+        run: |
+          oc login "$OPENSHIFT_SERVER" --token="$OPENSHIFT_TOKEN" --insecure-skip-tls-verify=true
+          if [ -n "$OPENSHIFT_NAMESPACE" ]; then
+            oc project "$OPENSHIFT_NAMESPACE"
+          fi
 
       - name: 'Get Helm'
         run: |

--- a/.github/workflows/ci-trivy-img-scan.yaml
+++ b/.github/workflows/ci-trivy-img-scan.yaml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag bcgov/api-services-portal:trivy-scan
       - name: Run Trivy Scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'bcgov/api-services-portal:trivy-scan'
           format: 'template'
@@ -24,6 +24,6 @@ jobs:
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
       - name: Upload Trivy Scan Results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -18,38 +18,10 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: actions/github-script@v8
+        uses: Mattraks/delete-workflow-runs@v2.1.0
         with:
-          script: |
-            const retainDays = 1;
-            const keepMinimumRuns = 5;
-            const workflowPattern = 'jira.yaml';
-            const cutoff = Date.now() - retainDays * 24 * 60 * 60 * 1000;
-            const { owner, repo } = context.repo;
-            const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, {
-              owner,
-              repo,
-              per_page: 100,
-            });
-            const matches = workflows.filter((workflow) =>
-              workflow.path?.includes(workflowPattern) || workflow.name?.includes(workflowPattern)
-            );
-
-            for (const workflow of matches) {
-              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-                owner,
-                repo,
-                workflow_id: workflow.id,
-                per_page: 100,
-              });
-              const deletableRuns = runs.filter((run, index) =>
-                index >= keepMinimumRuns &&
-                run.id !== context.runId &&
-                new Date(run.created_at).getTime() < cutoff
-              );
-
-              for (const run of deletableRuns) {
-                await github.rest.actions.deleteWorkflowRun({ owner, repo, run_id: run.id });
-                core.info(`Deleted ${workflow.path} run ${run.id}`);
-              }
-            }
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 1
+          keep_minimum_runs: 5
+          delete_workflow_pattern: jira.yaml

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -14,13 +14,42 @@ jobs:
     name: Delete workflow runs
     runs-on: ubuntu-latest
     permissions:
-      actions: write    
+      actions: write
+      contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: actions/github-script@v8
         with:
-          token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          retain_days: 1
-          keep_minimum_runs: 5
-          delete_workflow_pattern: jira.yaml
+          script: |
+            const retainDays = 1;
+            const keepMinimumRuns = 5;
+            const workflowPattern = 'jira.yaml';
+            const cutoff = Date.now() - retainDays * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+            const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const matches = workflows.filter((workflow) =>
+              workflow.path?.includes(workflowPattern) || workflow.name?.includes(workflowPattern)
+            );
+
+            for (const workflow of matches) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: workflow.id,
+                per_page: 100,
+              });
+              const deletableRuns = runs.filter((run, index) =>
+                index >= keepMinimumRuns &&
+                run.id !== context.runId &&
+                new Date(run.created_at).getTime() < cutoff
+              );
+
+              for (const run of deletableRuns) {
+                await github.rest.actions.deleteWorkflowRun({ owner, repo, run_id: run.id });
+                core.info(`Deleted ${workflow.path} run ${run.id}`);
+              }
+            }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,13 +16,13 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
@@ -41,10 +41,10 @@ jobs:
 
       - name: Set DEPLOY_ID
         run: |
-          echo "::set-output name=APP_REVISION::${GITHUB_SHA}"
+          echo "APP_REVISION=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
         id: set-deploy-id
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -53,10 +53,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Portal
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -70,7 +70,7 @@ jobs:
             APP_REVISION=${{ steps.set-deploy-id.outputs.APP_REVISION }}
 
       - name: Build Feeder
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/pr-reminder.yaml
+++ b/.github/workflows/pr-reminder.yaml
@@ -7,6 +7,11 @@ jobs:
   remind:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Run PR reviewer reminder
         uses: bcgov/aps-devops/pr-reminder@dev
         with:

--- a/.github/workflows/pr-reminder.yaml
+++ b/.github/workflows/pr-reminder.yaml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '30 13 * * 1,2,3,4,5' # Scheduled to run at 5:30 AM PST, weekdays
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   remind:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Implemented the Node.js 24 GitHub Actions upgrade work for this repo.

Changes made:
- Updated official GitHub actions to Node 24-compatible versions:
  - `actions/checkout` -> `v6`
  - `actions/cache` -> `v5`
  - `actions/upload-artifact` -> `v6`
  - `actions/setup-node` -> `v6`
  - `actions/setup-python` -> `v6`
  - `actions/github-script` -> `v8`
  - `github/codeql-action/upload-sarif` -> `v4`

- Updated commonly used third-party actions to Node 24-compatible versions:
  - Docker actions: `docker/metadata-action@v6`, `docker/login-action@v4`, `docker/setup-buildx-action@v4`, `docker/build-push-action@v7`
  - Sonar: `sonarsource/sonarqube-scan-action@v7`
  - Security scans: `aquasecurity/trivy-action@v0.36.0`, `anchore/scan-action@v7.4.0`
  - Chromatic: `chromaui/action@v16`
  - PR description helper: `bcgov-nr/action-pr-description-add@v2.0.1`

- Replaced Red Hat OpenShift actions that did not have a clear Node 24-compatible release:
  - Replaced `redhat-actions/oc-installer` / `redhat-actions/oc-login` with direct shell-based `oc` install/login steps.

- Kept existing compatible actions where verified:
  - `Mattraks/delete-workflow-runs@v2`
  - Composite/Docker actions that do not declare a deprecated JavaScript runtime.

- Also updated deprecated `::set-output` usage to `$GITHUB_OUTPUT`.

Validation completed locally:
- `actionlint` passed for top-level workflow files.
- `git diff --check -- .github/workflows` passed.
- No IDE linter errors reported for workflow files.

GHA validation once merged:
- Push/PR against `dev` to exercise the common build, deploy, Sonar, scan, PR-description, and Chromatic paths.
- Run `aps-cypress-e2e.yaml` via `workflow_dispatch`.
- Validate the `main` release workflow separately when changes are promoted to `main`, since it only runs on pushes to `main`.