### PR TITLE
APS-4620 Fix wrong user on namespace access edit when requesterEmail is null

### DIFF
--- a/src/lists/extensions/UMAPermissionTicket.ts
+++ b/src/lists/extensions/UMAPermissionTicket.ts
@@ -133,6 +133,31 @@ module.exports = {
                 perm.requesterName = user?.name || perm.requesterName;
                 perm.requesterEmail = user?.email;
               });
+
+              const permissionsWithoutEmail = permissions.filter(
+                (p) => !p.requesterEmail
+              );
+              if (permissionsWithoutEmail.length > 0) {
+                const userApi = new KeycloakUserService(envCtx.openid.issuer);
+                await userApi.login(
+                  envCtx.issuerEnvConfig.clientId,
+                  envCtx.issuerEnvConfig.clientSecret
+                );
+                const requesterIds = [
+                  ...new Set(
+                    permissionsWithoutEmail.map((p) => p.requester)
+                  ),
+                ];
+                for (const requesterId of requesterIds) {
+                  const kcUser = await userApi.lookupUserById(requesterId);
+                  permissions.forEach((perm) => {
+                    if (perm.requester === requesterId && !perm.requesterEmail) {
+                      perm.requesterEmail = kcUser.email;
+                    }
+                  });
+                }
+              }
+
               return permissions;
             },
             access: EnforcementPoint,

--- a/src/lists/extensions/UMAPermissionTicket.ts
+++ b/src/lists/extensions/UMAPermissionTicket.ts
@@ -149,12 +149,27 @@ module.exports = {
                   ),
                 ];
                 for (const requesterId of requesterIds) {
-                  const kcUser = await userApi.lookupUserById(requesterId);
-                  permissions.forEach((perm) => {
-                    if (perm.requester === requesterId && !perm.requesterEmail) {
-                      perm.requesterEmail = kcUser.email;
+                  try {
+                    const kcUser = await userApi.lookupUserById(requesterId);
+                    const requesterEmail = kcUser?.email;
+                    if (!requesterEmail) {
+                      continue;
                     }
-                  });
+                    permissions.forEach((perm) => {
+                      if (
+                        perm.requester === requesterId &&
+                        !perm.requesterEmail
+                      ) {
+                        perm.requesterEmail = requesterEmail;
+                      }
+                    });
+                  } catch (err) {
+                    logger.warn(
+                      '[getPermissionTicketsForResource] failed to resolve requester %s: %s',
+                      requesterId,
+                      err
+                    );
+                  }
                 }
               }
 

--- a/src/nextapp/components/namespace-access/users-access.tsx
+++ b/src/nextapp/components/namespace-access/users-access.tsx
@@ -32,7 +32,7 @@ interface UsersAccessProps {
 }
 
 const EDIT_UNAVAILABLE_MESSAGE =
-  'Email unavailable. Revoke access and re-grant with a valid email.';
+  'Email unavailable. Ask this user to sign in to the API Services Portal with IDIR, then refresh this page. If email is still unavailable, revoke access and re-grant using their email address.';
 
 function canEditUserAccess(item: AccessItem): boolean {
   return Boolean(item.requesterEmail?.trim());
@@ -143,16 +143,6 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
   const handleUpdateAccess = async (form: FormData) => {
     const email = (form.get('email') as string)?.trim();
     const scopes = form.getAll('scopes') as string[];
-
-    if (!email) {
-      toast({
-        status: 'error',
-        title: 'Unable to update user access',
-        description: 'Email is required. Reload the page and try again.',
-        isClosable: true,
-      });
-      return;
-    }
 
     try {
       await update.mutateAsync({

--- a/src/nextapp/components/namespace-access/users-access.tsx
+++ b/src/nextapp/components/namespace-access/users-access.tsx
@@ -31,6 +31,13 @@ interface UsersAccessProps {
   prodEnvId: string;
 }
 
+const EDIT_UNAVAILABLE_MESSAGE =
+  'Email unavailable. Revoke access and re-grant with a valid email.';
+
+function canEditUserAccess(item: AccessItem): boolean {
+  return Boolean(item.requesterEmail?.trim());
+}
+
 const UsersAccess: React.FC<UsersAccessProps> = ({
   resourceId,
   resourceScopes,
@@ -274,40 +281,56 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
         ]}
         data={requests}
       >
-        {(d: AccessItem, index) => (
-          <Tr key={uid(d)} data-testid={`nsa-users-table-row-${index}`}>
-            <Td>{d.requesterName}</Td>
-            <Td>
-              <Wrap>
-                {d.scopes.map((s) => (
-                  <WrapItem key={uid(s)}>
-                    <Tag variant="outline">{s.name.replace(/Namespace/g, 'Gateway')}</Tag>
-                  </WrapItem>
-                ))}
-              </Wrap>
-            </Td>
-            <Td textAlign="right">
-              <ActionsMenu
-                placement="bottom-end"
-                data-testid={`nsa-users-table-row-${index}-menu`}
-              >
-                <MenuItem
-                  onClick={handleEditAccess(d)}
-                  data-testid={`nsa-users-table-row-${index}-edit-btn`}
+        {(d: AccessItem, index) => {
+          const canEdit = canEditUserAccess(d);
+          return (
+            <Tr key={uid(d)} data-testid={`nsa-users-table-row-${index}`}>
+              <Td>
+                {d.requesterName}
+                {!canEdit && (
+                  <Text
+                    fontSize="sm"
+                    color="bc-component"
+                    mt={1}
+                    data-testid={`nsa-users-table-row-${index}-email-unavailable`}
+                  >
+                    {EDIT_UNAVAILABLE_MESSAGE}
+                  </Text>
+                )}
+              </Td>
+              <Td>
+                <Wrap>
+                  {d.scopes.map((s) => (
+                    <WrapItem key={uid(s)}>
+                      <Tag variant="outline">{s.name.replace(/Namespace/g, 'Gateway')}</Tag>
+                    </WrapItem>
+                  ))}
+                </Wrap>
+              </Td>
+              <Td textAlign="right">
+                <ActionsMenu
+                  placement="bottom-end"
+                  data-testid={`nsa-users-table-row-${index}-menu`}
                 >
-                  Edit Access
-                </MenuItem>
-                <MenuItem
-                  color="bc-error"
-                  onClick={handleRevokeAccess(d)}
-                  data-testid={`nsa-users-table-row-${index}-revoke-btn`}
-                >
-                  Revoke Access
-                </MenuItem>
-              </ActionsMenu>
-            </Td>
-          </Tr>
-        )}
+                  <MenuItem
+                    isDisabled={!canEdit}
+                    onClick={handleEditAccess(d)}
+                    data-testid={`nsa-users-table-row-${index}-edit-btn`}
+                  >
+                    Edit Access
+                  </MenuItem>
+                  <MenuItem
+                    color="bc-error"
+                    onClick={handleRevokeAccess(d)}
+                    data-testid={`nsa-users-table-row-${index}-revoke-btn`}
+                  >
+                    Revoke Access
+                  </MenuItem>
+                </ActionsMenu>
+              </Td>
+            </Tr>
+          );
+        }}
       </Table>
     </>
   );

--- a/src/nextapp/components/namespace-access/users-access.tsx
+++ b/src/nextapp/components/namespace-access/users-access.tsx
@@ -13,7 +13,6 @@ import {
   WrapItem,
 } from '@chakra-ui/react';
 import EmptyPane from '@/components/empty-pane';
-import get from 'lodash/get';
 import { gql } from 'graphql-request';
 import groupBy from 'lodash/groupBy';
 import NamespaceAccessDialog from './namespace-access-dialog';
@@ -76,11 +75,8 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
       );
       const result = Object.keys(groupedByRequester).map((r) => {
         const requesterName = r.split('|')[1];
-        const requesterEmail = get(
-          groupedByRequester[r],
-          '[0].requesterEmail',
-          requesterName
-        );
+        const requesterEmail =
+          groupedByRequester[r][0]?.requesterEmail ?? undefined;
         return {
           requesterName,
           requesterEmail,
@@ -100,8 +96,18 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
   }, [data, isSuccess, search]);
 
   const handleGrantAccess = async (form: FormData) => {
-    const email = form.get('email') as string;
+    const email = (form.get('email') as string)?.trim();
     const scopes = form.getAll('scopes') as string[];
+
+    if (!email) {
+      toast({
+        status: 'error',
+        title: 'Unable to grant user access',
+        description: 'Email is required.',
+        isClosable: true,
+      });
+      return;
+    }
 
     try {
       await grant.mutateAsync({
@@ -128,8 +134,18 @@ const UsersAccess: React.FC<UsersAccessProps> = ({
     }
   };
   const handleUpdateAccess = async (form: FormData) => {
-    const email = form.get('email') as string;
+    const email = (form.get('email') as string)?.trim();
     const scopes = form.getAll('scopes') as string[];
+
+    if (!email) {
+      toast({
+        status: 'error',
+        title: 'Unable to update user access',
+        description: 'Email is required. Reload the page and try again.',
+        isClosable: true,
+      });
+      return;
+    }
 
     try {
       await update.mutateAsync({

--- a/src/services/keycloak/user-service.ts
+++ b/src/services/keycloak/user-service.ts
@@ -35,7 +35,7 @@ export class KeycloakUserService {
    * Mirrors auth-oauth2-proxy migration logic: the legacy account username is
    * provider_username@identity_provider, while federated accounts use a GUID.
    */
-  public isLegacyIdirUser(user: UserRepresentation): boolean {
+  private isLegacyIdirUser(user: UserRepresentation): boolean {
     const identityProvider = this.getOneAttributeValue(
       user,
       'identity_provider'

--- a/src/services/keycloak/user-service.ts
+++ b/src/services/keycloak/user-service.ts
@@ -66,19 +66,17 @@ export class KeycloakUserService {
     identityProviders: string[]
   ): Promise<UserRepresentation> {
     const matchingUsers = await this.lookupActiveUsersByEmail(email, verified);
-    const user = matchingUsers
-      .filter((user) =>
-        identityProviders.includes(
-          this.getOneAttributeValue(user, 'identity_provider')
-        )
+    const usersForIdentityProviders = matchingUsers.filter((user) =>
+      identityProviders.includes(
+        this.getOneAttributeValue(user, 'identity_provider')
       )
-      .pop();
-    assert.strictEqual(
-      Boolean(user),
-      true,
-      `No suitable match for ${identityProviders.join(',')} : ${email}`
     );
-    return user;
+    assert.strictEqual(
+      usersForIdentityProviders.length,
+      1,
+      `Expected exactly one ${identityProviders.join(',')} user for ${email}, found ${usersForIdentityProviders.length}`
+    );
+    return usersForIdentityProviders[0];
   }
 
   public async lookupActiveUsersByEmail(

--- a/src/services/keycloak/user-service.ts
+++ b/src/services/keycloak/user-service.ts
@@ -31,6 +31,28 @@ export class KeycloakUserService {
       : undefined;
   }
 
+  /**
+   * Mirrors auth-oauth2-proxy migration logic: the legacy account username is
+   * provider_username@identity_provider, while federated accounts use a GUID.
+   */
+  public isLegacyIdirUser(user: UserRepresentation): boolean {
+    const identityProvider = this.getOneAttributeValue(
+      user,
+      'identity_provider'
+    );
+    const providerUsername = this.getOneAttributeValue(
+      user,
+      'provider_username'
+    );
+    if (!identityProvider || !providerUsername || !user.username) {
+      return false;
+    }
+    const expectedLegacyUsername = providerUsername.includes('@')
+      ? providerUsername.toLowerCase()
+      : `${providerUsername}@${identityProvider}`.toLowerCase();
+    return user.username.toLowerCase() === expectedLegacyUsername;
+  }
+
   public async lookupUserByUsername(username: string) {
     logger.debug('[lookupUserByUsername] %s', username);
     const users = await this.kcAdminClient.users.find({
@@ -72,11 +94,24 @@ export class KeycloakUserService {
       )
     );
     assert.strictEqual(
-      usersForIdentityProviders.length,
+      usersForIdentityProviders.length > 0,
+      true,
+      `No suitable match for ${identityProviders.join(',')} : ${email}`
+    );
+    if (usersForIdentityProviders.length === 1) {
+      return usersForIdentityProviders[0];
+    }
+
+    // During IDIR migration, legacy and federated accounts may share an email.
+    const legacyUsers = usersForIdentityProviders.filter((user) =>
+      this.isLegacyIdirUser(user)
+    );
+    assert.strictEqual(
+      legacyUsers.length,
       1,
       `Expected exactly one ${identityProviders.join(',')} user for ${email}, found ${usersForIdentityProviders.length}`
     );
-    return usersForIdentityProviders[0];
+    return legacyUsers[0];
   }
 
   public async lookupActiveUsersByEmail(

--- a/src/services/workflow/ns-uma-perm-access.ts
+++ b/src/services/workflow/ns-uma-perm-access.ts
@@ -21,7 +21,19 @@ export async function updatePermissions(
   resourceId: string,
   grant: 'grant' | 'update' = 'update'
 ): Promise<{ userId: string; result: { id: string }[] }> {
-  logger.debug('[updatePermissions] %s : %s %s', email, resourceId, scopes);
+  const normalizedEmail = email?.trim() ?? '';
+  logger.debug(
+    '[updatePermissions] %s : %s %s',
+    normalizedEmail,
+    resourceId,
+    scopes
+  );
+
+  assert.strictEqual(
+    normalizedEmail.length > 0,
+    true,
+    'Email is required to grant or update user access'
+  );
 
   await enforceAccessToResource(envCtx, resourceId);
 
@@ -30,7 +42,11 @@ export async function updatePermissions(
     envCtx.issuerEnvConfig.clientId,
     envCtx.issuerEnvConfig.clientSecret
   );
-  const user = await userApi.lookupUserByEmail(email, false, ['idir']);
+  const user = await userApi.lookupUserByEmail(
+    normalizedEmail,
+    false,
+    ['idir']
+  );
   const displayName =
     userApi.getOneAttributeValue(user, 'display_name') || user.email;
 

--- a/src/test/services/keycloak/user-service.test.ts
+++ b/src/test/services/keycloak/user-service.test.ts
@@ -1,0 +1,128 @@
+import { KeycloakUserService } from '../../../services/keycloak/user-service';
+
+describe('KeycloakUserService', function () {
+  describe('lookupUserByEmail', function () {
+    it('prefers legacy account when multiple idir users share an email (test fixture)', async function () {
+      const kc = new KeycloakUserService('https://provider/realms/abc');
+      kc.useAdminClient({
+        users: {
+          find: jest.fn().mockResolvedValue([
+            {
+              id: 'new-user-id',
+              username: '220469e037c84a7abdfab15204a60701@olduser',
+              email: 'olduser@testmail.com',
+              enabled: true,
+              attributes: {
+                identity_provider: ['idir'],
+                provider_username: ['olduser'],
+              },
+            },
+            {
+              id: 'legacy-user-id',
+              username: 'olduser@idir',
+              email: 'olduser@testmail.com',
+              enabled: true,
+              attributes: {
+                identity_provider: ['idir'],
+                provider_username: ['olduser@idir'],
+              },
+            },
+          ]),
+        },
+      } as any);
+
+      const user = await kc.lookupUserByEmail(
+        'olduser@testmail.com',
+        false,
+        ['idir']
+      );
+
+      expect(user.id).toBe('legacy-user-id');
+    });
+
+    it('prefers legacy account when both users use @idir usernames (production)', async function () {
+      const kc = new KeycloakUserService('https://provider/realms/abc');
+      kc.useAdminClient({
+        users: {
+          find: jest.fn().mockResolvedValue([
+            {
+              id: 'federated-user-id',
+              username: 'af8b80da00934b11b7f0485d9066609a@idir',
+              email: 'jdoe@gov.bc.ca',
+              enabled: true,
+              attributes: {
+                identity_provider: ['idir'],
+                provider_username: ['jdoe'],
+              },
+            },
+            {
+              id: 'legacy-user-id',
+              username: 'jdoe@idir',
+              email: 'jdoe@gov.bc.ca',
+              enabled: true,
+              attributes: {
+                identity_provider: ['idir'],
+                provider_username: ['jdoe'],
+              },
+            },
+          ]),
+        },
+      } as any);
+
+      const user = await kc.lookupUserByEmail(
+        'jdoe@gov.bc.ca',
+        false,
+        ['idir']
+      );
+
+      expect(user.id).toBe('legacy-user-id');
+    });
+
+    it('returns the only match when email is unique', async function () {
+      const kc = new KeycloakUserService('https://provider/realms/abc');
+      kc.useAdminClient({
+        users: {
+          find: jest.fn().mockResolvedValue([
+            {
+              id: 'user-id',
+              username: 'wendy@idir',
+              email: 'wendy@idir',
+              enabled: true,
+              attributes: { identity_provider: ['idir'] },
+            },
+          ]),
+        },
+      } as any);
+
+      const user = await kc.lookupUserByEmail('wendy@idir', false, ['idir']);
+
+      expect(user.id).toBe('user-id');
+    });
+  });
+
+  describe('isLegacyIdirUser', function () {
+    it('identifies legacy and federated idir accounts', function () {
+      const kc = new KeycloakUserService('https://provider/realms/abc');
+
+      expect(
+        kc.isLegacyIdirUser({
+          username: 'jdoe@idir',
+          attributes: {
+            identity_provider: ['idir'],
+            provider_username: ['jdoe'],
+          },
+        })
+      ).toBe(true);
+
+      expect(
+        kc.isLegacyIdirUser({
+          username: 'af8b80da00934b11b7f0485d9066609a@idir',
+          attributes: {
+            identity_provider: ['idir'],
+            provider_username: ['jdoe'],
+          },
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/test/services/keycloak/user-service.test.ts
+++ b/src/test/services/keycloak/user-service.test.ts
@@ -99,30 +99,4 @@ describe('KeycloakUserService', function () {
       expect(user.id).toBe('user-id');
     });
   });
-
-  describe('isLegacyIdirUser', function () {
-    it('identifies legacy and federated idir accounts', function () {
-      const kc = new KeycloakUserService('https://provider/realms/abc');
-
-      expect(
-        kc.isLegacyIdirUser({
-          username: 'jdoe@idir',
-          attributes: {
-            identity_provider: ['idir'],
-            provider_username: ['jdoe'],
-          },
-        })
-      ).toBe(true);
-
-      expect(
-        kc.isLegacyIdirUser({
-          username: 'af8b80da00934b11b7f0485d9066609a@idir',
-          attributes: {
-            identity_provider: ['idir'],
-            provider_username: ['jdoe'],
-          },
-        })
-      ).toBe(false);
-    });
-  });
 });

--- a/src/test/services/workflow/ns-uma-access-activity.test.ts
+++ b/src/test/services/workflow/ns-uma-access-activity.test.ts
@@ -108,6 +108,19 @@ describe('gateway namespace access activity always uses "updated" and is signed 
       );
     });
 
+    it('rejects empty email', async function () {
+      await expect(
+        updatePermissions(
+          buildContext(),
+          permEnvCtx,
+          '  ',
+          ['Namespace.Manage'],
+          RESOURCE_ID,
+          'update'
+        )
+      ).rejects.toThrow('Email is required to grant or update user access');
+    });
+
     it('edit access records "updated" with mixed [+]/[-] markers', async function () {
       UserServiceMock.mockImplementation(() => ({
         login: jest.fn().mockResolvedValue({}),


### PR DESCRIPTION
## Summary

Fixes a bug where editing namespace user access for someone who has not logged into the portal could apply permissions to the wrong Keycloak user.

## Changes

- **Read:** `getPermissionTicketsForResource` falls back to Keycloak Admin API for email when Keystone has no user/email.
- **Write:** Reject empty/whitespace email on grant/update; require exactly one identity-provider match in `lookupUserByEmail`.
- **UI:** Trim email and show an error if grant/update is submitted without one.

## Test plan

- [ ] Grant access to a user who has not logged in; confirm edit modal shows their email after reload.
- [ ] Edit scopes for that user; confirm permissions stay on the correct user.
- [ ] Confirm grant/update with empty email is blocked (UI toast / API error).

---
🚀 Feature branch deployment: https://api-services-portal-feature-aps-4620-email-lookup.apps.silver.devops.gov.bc.ca