### PR TITLE
APS-4652 Fix SDX peer-to-peer gateway resolution

### DIFF
--- a/src/auth/auth-sdx-middle.ts
+++ b/src/auth/auth-sdx-middle.ts
@@ -54,6 +54,10 @@ export class AuthMiddle {
       return await this.lookupSubsystemGateway(org, body.parameters.clientId);
     }
 
+    if (pattern === 'sdx-p2p-consumer.r1' && body.parameters?.clientId) {
+      return await this.lookupSubsystemGateway(org, body.parameters.clientId);
+    }
+
     if (
       pattern === 'sdx-runtime-group.r1' &&
       body.parameters?.runtimeGroupName
@@ -69,8 +73,14 @@ export class AuthMiddle {
       return await this.lookupServiceGateway(org, body.parameters.serviceId);
     }
 
+    if (pattern === 'sdx-p2p-provider.r1' && body.parameters?.serviceId) {
+      return await this.lookupServiceGateway(org, body.parameters.serviceId);
+    }
+
     const validPatterns = [
       'sdx-keys.r1',
+      'sdx-p2p-consumer.r1',
+      'sdx-p2p-provider.r1',
       'sdx-runtime-group.r1',
       'sdx-service.r1',
       'sdx-subsystem.r1',


### PR DESCRIPTION
## Summary

- Resolve `sdx-p2p-consumer.r1` authorization through the subsystem gateway using `parameters.clientId`.
- Resolve `sdx-p2p-provider.r1` authorization through the service gateway using `parameters.serviceId`.
- Add both peer-to-peer patterns to the valid-pattern list.
- Leave gateway resolution unresolved when the required identifier is missing.

## Testing

- Verified consumer and provider gateway resolution.
- Verified missing identifiers do not select another gateway.
- Verified existing subsystem, runtime-group, service, and connection mappings.
- `git diff --check` passes.

---
🚀 Feature branch deployment: https://api-services-portal-feature-aps-4652-p2p-gateway.apps.silver.devops.gov.bc.ca