### PR TITLE
PLAT-001: reject unsupported organization-access roles

### DIFF
--- a/src/services/org-groups/group-access.ts
+++ b/src/services/org-groups/group-access.ts
@@ -46,12 +46,12 @@ export class GroupAccessService {
     // ["system-owner"]` (a valid *system-level* role, not a supported
     // *organization*-level one) 204'd without assigning anything. Fail
     // fast and name the offending role(s) instead.
+    const submittedRoles: string[] = (groupMembership.members ?? []).reduce(
+      (acc: string[], member: GroupMember) => acc.concat(member.roles ?? []),
+      []
+    );
     const unsupportedRoles = Array.from(
-      new Set(
-        (groupMembership.members ?? [])
-          .flatMap((member) => member.roles ?? [])
-          .filter((role) => !OrganizationRoles.includes(role))
-      )
+      new Set(submittedRoles.filter((role: string) => !OrganizationRoles.includes(role)))
     );
     assert.strictEqual(
       unsupportedRoles.length === 0,

--- a/src/services/org-groups/group-access.ts
+++ b/src/services/org-groups/group-access.ts
@@ -41,6 +41,25 @@ export class GroupAccessService {
     const granted: Record<string, Set<string>> = {};
     const revoked: Record<string, Set<string>> = {};
 
+    // PLAT-001: previously any role name not in OrganizationRoles was
+    // silently dropped from the sync loop below, so e.g. `roles:
+    // ["system-owner"]` (a valid *system-level* role, not a supported
+    // *organization*-level one) 204'd without assigning anything. Fail
+    // fast and name the offending role(s) instead.
+    const unsupportedRoles = Array.from(
+      new Set(
+        (groupMembership.members ?? [])
+          .flatMap((member) => member.roles ?? [])
+          .filter((role) => !OrganizationRoles.includes(role))
+      )
+    );
+    assert.strictEqual(
+      unsupportedRoles.length === 0,
+      true,
+      `Unsupported organization role(s): ${unsupportedRoles.join(', ')}. ` +
+        `Supported organization roles are: ${OrganizationRoles.join(', ')}.`
+    );
+
     const access = buildGroupAccess(
       groupMembership.name,
       groupMembership.parent,


### PR DESCRIPTION
## Summary

`createOrUpdateGroupAccess` filtered its sync loop down to `OrganizationRoles` (`organization-admin`, `system-admin`) but never validated the caller's submitted role names against that set first. Submitting an unsupported role (e.g. `system-owner` — a real `PredefinedRolePermissions` key, just not a supported *organization*-level role) silently matched nothing in the loop; the call still returned `204` and granted nothing, with no way for the caller to tell the write was a no-op.

Now validates every submitted role up front and throws naming the unsupported value(s).

## Test plan

- [x] `node e2e-sdx/run.js --test plat-001` (from the paired harness PR #1506): before the fix, `put-organization-access` with `roles: ["system-owner"]` returned `204` and logged `CONFIRMED`. After rebuilding with this fix and re-running, the same call now returns a 4xx naming the role and the scenario logs `RESOLVED`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>