### PR TITLE
ERR-013: reject subsystem gateway registration for an org the runtime doesn't host

### DIFF
--- a/src/services/batch/runtime-group.ts
+++ b/src/services/batch/runtime-group.ts
@@ -179,9 +179,22 @@ class RuntimeGroupService {
       'Runtime group does not exist'
     );
 
-    return runtimeGroups.filter((rg) =>
+    const hostedByOrg = runtimeGroups.filter((rg) =>
       rg.hostedOrganizations.some((o: any) => o.name === org)
     );
+
+    // ERR-013: a runtime group existing by *name* is not the same as it
+    // hosting *this* organization - previously an empty filtered result
+    // here was returned as-is, so callers (e.g. registerSubsystemGateway)
+    // proceeded to create a namespace with no host domain instead of
+    // being rejected.
+    assert.strictEqual(
+      hostedByOrg.length > 0,
+      true,
+      `Runtime group '${name}' does not host organization '${org}'`
+    );
+
+    return hostedByOrg;
   };
 
   findOrgRuntimeGroupsByName = async (


### PR DESCRIPTION
## Summary

`findHostedRuntimeGroupsByName` asserted only that a runtime group with the given *name* exists anywhere, then filtered by `hostedOrganizations` without checking the filtered result was non-empty. Every call site (`registerSubsystemGateway` via `CreateNamespaceForSubsystem`, `CreateNamespaceForRuntimeGroup`, `OrgRuntimeGroupController`, the gateway-patterns catalog lookup) already assumes a non-empty result — some index `runtimeGroups[0]` directly — so an empty filtered result previously either silently produced a namespace with no host domain (`CreateNamespaceForSubsystem`, the exact reproduction here) or would have thrown a confusing "reading 'namespace' of undefined" elsewhere.

Now fails clearly and immediately, naming both the runtime group and the org.

## Test plan

- [x] `node e2e-sdx/run.js --test err-013` (from the paired harness PR #1506): before the fix, registering a subsystem against a runtime group that doesn't host its org returned `200`/a gateway id, and a follow-up `get-subsystem-client` showed `runtimeGroups: []`. After rebuilding with this fix, the same registration now returns a 4xx naming `Runtime group '<name>' does not host organization '<org>'`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>