### PR TITLE
ERR-014: make subsystem gateway registration an idempotent reconcile

### DIFF
--- a/src/services/org-groups/namespace.ts
+++ b/src/services/org-groups/namespace.ts
@@ -150,6 +150,11 @@ export class NamespaceService {
     assert.strictEqual(groupExists, false, 'Namespace already exists');
   }
 
+  /** Non-throwing existence check - see CreateNamespace's reconcile path (ERR-014). */
+  async namespaceExists(ns: string): Promise<boolean> {
+    return await this.groupService.hasGroup('ns', ns);
+  }
+
   async listAssignedNamespacesByOrg(org: string): Promise<OrgNamespace[]> {
     const groups = await this.groupService.getGroups('ns', false);
     assert.strictEqual(

--- a/src/services/workflow/create-namespace-sdx.ts
+++ b/src/services/workflow/create-namespace-sdx.ts
@@ -12,7 +12,7 @@ import { CreateNamespace, CreateNamespaceArgs } from './create-namespace';
 import assert from '../user-assert';
 import { EnvironmentContext, getEnvironmentContext } from './get-namespaces';
 import { lookupProductEnvironmentServicesBySlug } from '../keystone';
-import { createUmaPolicy, updateUmaPolicy } from './ns-uma-policy-access';
+import { upsertUmaPolicy, updateUmaPolicy } from './ns-uma-policy-access';
 import { SysGroupAccessService } from '../org-groups/sys-group-access';
 import { GroupAccessService } from '../org-groups';
 
@@ -308,7 +308,7 @@ async function createSDXNamespace(
     scopes: ['GatewayConfig.Publish', 'Namespace.Manage'],
   };
 
-  const umaResult = await createUmaPolicy(
+  const umaResult = await upsertUmaPolicy(
     context,
     envCtx,
     resourceSet.id,

--- a/src/services/workflow/create-namespace.ts
+++ b/src/services/workflow/create-namespace.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from 'assert';
 import {
   getResourceSets,
   isUserBasedResourceOwners,
@@ -67,7 +68,13 @@ export async function CreateNamespace(
     envCtx.issuerEnvConfig.clientId,
     envCtx.issuerEnvConfig.clientSecret
   );
-  await nsService.checkNamespaceAvailable(newNS);
+  // ERR-014: registration is now an idempotent reconcile, not create-only.
+  // checkNamespaceAvailable's unconditional throw meant repeating an
+  // otherwise-identical registration (or retrying after a partial
+  // failure) always 422'd with "Namespace already exists" and there was
+  // no supported way to update perm-domains/perm-route-paths/etc. on an
+  // existing namespace.
+  const nsAlreadyExists = await nsService.namespaceExists(newNS);
 
   // This function gets all resources but also sets the accessToken in envCtx
   // which we need to create the resource set
@@ -78,45 +85,60 @@ export async function CreateNamespace(
     envCtx.accessToken
   );
 
-  const scopes: string[] = [
-    'Namespace.Manage',
-    'Namespace.View',
-    'GatewayConfig.Publish',
-    'Access.Manage',
-    'Content.Publish',
-    'CredentialIssuer.Admin',
-  ];
-  if (args.includeSDXScopes) {
-    scopes.push('Connection.Manage');
-    scopes.push('GatewayPattern.Publish');
-  }
-  const res = <ResourceSetInput>{
-    name: newNS,
-    displayName,
-    type: 'namespace',
-    resource_scopes: scopes,
-    ownerManagedAccess: true,
-  };
+  let rset: ResourceSet;
 
-  const rset = await resourceApi.createResourceSet(res);
-
-  if (isUserBasedResourceOwners(envCtx) == false) {
-    const permissionApi = new KeycloakPermissionTicketService(
-      envCtx.issuerEnvConfig.issuerUrl,
-      envCtx.accessToken
+  if (nsAlreadyExists) {
+    // The UMA resource set and its permission tickets identify the
+    // namespace itself and aren't recreated on reconcile - only the
+    // mutable Keycloak group attributes (below) are brought in line with
+    // the requested args.
+    rset = await resourceApi.findResourceByName(newNS);
+    assert.strictEqual(
+      rset !== undefined,
+      true,
+      `Namespace '${newNS}' has a Keycloak group but no matching UMA resource - manual repair required`
     );
-    for (const scope of args.assignedScopes || [
+  } else {
+    const scopes: string[] = [
       'Namespace.Manage',
-      'CredentialIssuer.Admin',
+      'Namespace.View',
       'GatewayConfig.Publish',
       'Access.Manage',
-    ]) {
-      await permissionApi.createPermission(
-        rset.id,
-        envCtx.subjectUuid,
-        true,
-        scope
+      'Content.Publish',
+      'CredentialIssuer.Admin',
+    ];
+    if (args.includeSDXScopes) {
+      scopes.push('Connection.Manage');
+      scopes.push('GatewayPattern.Publish');
+    }
+    const res = <ResourceSetInput>{
+      name: newNS,
+      displayName,
+      type: 'namespace',
+      resource_scopes: scopes,
+      ownerManagedAccess: true,
+    };
+
+    rset = await resourceApi.createResourceSet(res);
+
+    if (isUserBasedResourceOwners(envCtx) == false) {
+      const permissionApi = new KeycloakPermissionTicketService(
+        envCtx.issuerEnvConfig.issuerUrl,
+        envCtx.accessToken
       );
+      for (const scope of args.assignedScopes || [
+        'Namespace.Manage',
+        'CredentialIssuer.Admin',
+        'GatewayConfig.Publish',
+        'Access.Manage',
+      ]) {
+        await permissionApi.createPermission(
+          rset.id,
+          envCtx.subjectUuid,
+          true,
+          scope
+        );
+      }
     }
   }
 
@@ -128,33 +150,35 @@ export async function CreateNamespace(
     envCtx.issuerEnvConfig.clientSecret
   );
 
-  const { id, created } = await kcGroupService.createIfMissing('ns', newNS);
+  const { id } = await kcGroupService.createIfMissing('ns', newNS);
 
-  if (created) {
-    const gwGroup = await kcGroupService.getGroupById(id);
-    if (args.org) {
-      gwGroup.attributes['org'] = [args.org];
-    }
-    if (args.orgUnit) {
-      gwGroup.attributes['org-unit'] = [args.orgUnit];
-    }
-    if (args.orgEnabled) {
-      gwGroup.attributes['org-enabled'] = [`${args.orgEnabled}`];
-    }
-    if (args.dataPlane) {
-      gwGroup.attributes['perm-data-plane'] = [args.dataPlane];
-    }
-    if (args.domains) {
-      gwGroup.attributes['perm-domains'] = args.domains;
-    }
-    if (args.runtimeGroupName) {
-      gwGroup.attributes['perm-runtime-group'] = [args.runtimeGroupName];
-    }
-    if (args.routePaths) {
-      gwGroup.attributes['perm-route-paths'] = args.routePaths;
-    }
-    await kcGroupService.updateGroup(gwGroup);
+  // Reconcile attributes whether the group was just created or already
+  // existed - previously this was gated on `created`, so re-registering
+  // an existing namespace with updated domains/route-paths silently kept
+  // the stale values.
+  const gwGroup = await kcGroupService.getGroupById(id);
+  if (args.org) {
+    gwGroup.attributes['org'] = [args.org];
   }
+  if (args.orgUnit) {
+    gwGroup.attributes['org-unit'] = [args.orgUnit];
+  }
+  if (args.orgEnabled) {
+    gwGroup.attributes['org-enabled'] = [`${args.orgEnabled}`];
+  }
+  if (args.dataPlane) {
+    gwGroup.attributes['perm-data-plane'] = [args.dataPlane];
+  }
+  if (args.domains) {
+    gwGroup.attributes['perm-domains'] = args.domains;
+  }
+  if (args.runtimeGroupName) {
+    gwGroup.attributes['perm-runtime-group'] = [args.runtimeGroupName];
+  }
+  if (args.routePaths) {
+    gwGroup.attributes['perm-route-paths'] = args.routePaths;
+  }
+  await kcGroupService.updateGroup(gwGroup);
 
   await recordActivity(
     context.sudo(),

--- a/src/services/workflow/ns-uma-policy-access.ts
+++ b/src/services/workflow/ns-uma-policy-access.ts
@@ -45,9 +45,22 @@ export async function createUmaPolicy(
  * registration but 409-conflicts ("Policy ... already exists") on any
  * retry once CreateNamespace itself became a reconcile instead of
  * create-only - reusing the existing namespace resource still hit this
- * unconditional create. Checks for an existing policy for this
- * resource+client first and reconciles (updateUmaPolicy) instead of
- * blindly creating.
+ * unconditional create.
+ *
+ * Tries create first and, on a 409 from that create call, treats it as
+ * already-correctly-configured rather than an error.
+ *
+ * This deliberately doesn't attempt a full reconcile (diffing and
+ * re-applying scopes via updateUmaPolicy): that path also depends on
+ * listPolicies, and live testing found the UMA protection API's list
+ * endpoint (GET .../uma-policy?resource=...) rejects the same
+ * envCtx.accessToken the create POST accepts, with `invalid_bearer_token`,
+ * in this environment - a separate, pre-existing gap in this Keycloak
+ * client's protection-API permissions, not something introduced here.
+ * Treating 409-already-exists as success avoids that broken call and
+ * fixes the actual reported symptom (registration retry always failing);
+ * it just can't detect or repair a policy whose scopes have drifted from
+ * what a fresh registration would create.
  */
 export async function upsertUmaPolicy(
   context: any,
@@ -55,33 +68,20 @@ export async function upsertUmaPolicy(
   resourceId: string,
   policy: Policy
 ) {
-  // Both branches below (createUmaPolicy/updateUmaPolicy) already call
-  // enforceAccessToResource themselves - not duplicated here.
-  const policyApi = new UMAPolicyService(
-    envCtx.uma2.policy_endpoint,
-    envCtx.accessToken
-  );
-
-  const existing = (await policyApi.listPolicies({ resource: resourceId }))
-    .filter((p) => policy.clients?.every((c) => p.clients?.includes(c)))
-    .pop();
-
-  if (existing) {
+  try {
+    return await createUmaPolicy(context, envCtx, resourceId, policy);
+  } catch (err) {
+    const statusCode = (err as any)?.errors?.[0]?.statusCode;
+    if (statusCode !== 409) {
+      throw err;
+    }
     logger.debug(
-      '[upsertUmaPolicy] existing policy found for %s, reconciling: %j',
+      '[upsertUmaPolicy] policy already exists for %s, treating as already-configured: %j',
       resourceId,
-      existing
+      policy
     );
-    return await updateUmaPolicy(
-      context,
-      envCtx,
-      resourceId,
-      policy.clients![0],
-      policy.scopes
-    );
+    return { name: policy.name };
   }
-
-  return await createUmaPolicy(context, envCtx, resourceId, policy);
 }
 
 export async function updateUmaPolicy(

--- a/src/services/workflow/ns-uma-policy-access.ts
+++ b/src/services/workflow/ns-uma-policy-access.ts
@@ -39,6 +39,51 @@ export async function createUmaPolicy(
   return umaPolicy;
 }
 
+/**
+ * ERR-014 (follow-on): createSDXNamespace unconditionally called
+ * createUmaPolicy after CreateNamespace, which is fine on first
+ * registration but 409-conflicts ("Policy ... already exists") on any
+ * retry once CreateNamespace itself became a reconcile instead of
+ * create-only - reusing the existing namespace resource still hit this
+ * unconditional create. Checks for an existing policy for this
+ * resource+client first and reconciles (updateUmaPolicy) instead of
+ * blindly creating.
+ */
+export async function upsertUmaPolicy(
+  context: any,
+  envCtx: EnvironmentContext,
+  resourceId: string,
+  policy: Policy
+) {
+  // Both branches below (createUmaPolicy/updateUmaPolicy) already call
+  // enforceAccessToResource themselves - not duplicated here.
+  const policyApi = new UMAPolicyService(
+    envCtx.uma2.policy_endpoint,
+    envCtx.accessToken
+  );
+
+  const existing = (await policyApi.listPolicies({ resource: resourceId }))
+    .filter((p) => policy.clients?.every((c) => p.clients?.includes(c)))
+    .pop();
+
+  if (existing) {
+    logger.debug(
+      '[upsertUmaPolicy] existing policy found for %s, reconciling: %j',
+      resourceId,
+      existing
+    );
+    return await updateUmaPolicy(
+      context,
+      envCtx,
+      resourceId,
+      policy.clients![0],
+      policy.scopes
+    );
+  }
+
+  return await createUmaPolicy(context, envCtx, resourceId, policy);
+}
+
 export async function updateUmaPolicy(
   context: any,
   envCtx: EnvironmentContext,


### PR DESCRIPTION
## Summary

`checkNamespaceAvailable`'s unconditional throw meant repeating an already-successful registration (or retrying after a partial failure) always 422'd with "Namespace already exists", with no supported way to update `perm-domains`/`perm-route-paths`/etc. on an existing namespace.

`CreateNamespace` now checks existence via a new non-throwing `NamespaceService.namespaceExists` instead: on an existing namespace it looks up the matching UMA resource set by name (`findResourceByName`) rather than recreating it and its permission tickets, then always reconciles the Keycloak group's attributes (previously gated behind `created`, so even a fixed create-only bug would have left attribute updates silently no-op'ing on an existing group).

Live re-verification of the first commit surfaced a second, downstream create-only step: `createSDXNamespace` unconditionally called `createUmaPolicy` for the `sdx-provisioner` client after `CreateNamespace` returns — which 409-conflicted on retry. The obvious fix (checking existence via `listPolicies` first) itself hit a separate, pre-existing gap: that endpoint rejects the same bearer token the create/update POST endpoints accept, in this environment. The final commit instead tries create first and treats a 409 as already-correctly-configured, avoiding the broken endpoint.

3 commits, in order: the core reconcile, the UMA-policy follow-on, and the endpoint-workaround correction.

## Test plan

- [x] `node e2e-sdx/run.js --test err-014` (from the paired harness PR #1506): before the fix, repeating `register-subsystem-gateway` with identical parameters returned `422 Namespace already exists`. After rebuilding with all 3 commits and re-running, the same repeat call now returns `200`/reconciled.
- [x] `node e2e-sdx/run.js` (happy-path) confirmed no regression after each commit.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>