### PR TITLE
ERR-015: distinguish validator engine failures from real unavailability

### DIFF
--- a/src/api-openapi.js
+++ b/src/api-openapi.js
@@ -212,6 +212,21 @@ class ApiOpenapiApp {
           code: 'validation_service_unavailable',
           message: 'OAS validation service unavailable',
         });
+      } else if (err?.name === 'OpenAPISpecValidationEngineError') {
+        // ERR-015: the validator was reachable but rejected the request
+        // itself (e.g. an internal engine crash, a malformed-body 400) -
+        // distinct from genuine unavailability above. Preserve its real
+        // status/diagnostic text instead of reporting a generic 503.
+        logger.error(
+          `Caught OpenAPI Spec Validation Engine Error for ${req.path}:`,
+          err.message
+        );
+        return res.status(502).json({
+          code: 'validation_engine_error',
+          message: err.message,
+          validatorStatus: err.status,
+          validatorBody: err.body,
+        });
       } else if (err instanceof ValidateError) {
         logger.error(
           `Caught Validation Error for ${req.path} '%s' %j`,

--- a/src/services/workflow/openapi-spec-validation-service.ts
+++ b/src/services/workflow/openapi-spec-validation-service.ts
@@ -50,6 +50,33 @@ export class OpenAPISpecValidationServiceUnavailableError extends Error {
   }
 }
 
+/**
+ * ERR-015: the validator responded (it's reachable), but rejected the
+ * request itself - a Spectral engine crash, a malformed-body 400, an
+ * unsupported version/ruleset, etc. This is distinct from
+ * OpenAPISpecValidationServiceUnavailableError, which is now reserved for
+ * genuine connectivity failures (timeouts, aborts, network errors -
+ * fetchWithTimeout's catch block below). Conflating the two previously
+ * sent operators chasing availability/network issues for problems that
+ * were actually in the validator engine or rules runtime.
+ */
+export class OpenAPISpecValidationEngineError extends Error {
+  public status: number;
+  public statusText: string;
+  public body?: string;
+
+  constructor(status: number, statusText: string, body?: string) {
+    super(
+      `OAS validation service rejected the request: ${status} ${statusText}` +
+        (body ? ` - ${body}` : '')
+    );
+    this.name = 'OpenAPISpecValidationEngineError';
+    this.status = status;
+    this.statusText = statusText;
+    this.body = body;
+  }
+}
+
 export class OpenAPISpecValidationService {
   private validationApiUrl: string;
   private version?: string;
@@ -119,9 +146,7 @@ export class OpenAPISpecValidationService {
         res.statusText,
         body
       );
-      throw new OpenAPISpecValidationServiceUnavailableError(
-        `OAS validation service unavailable: ${res.status} ${res.statusText}`
-      );
+      throw new OpenAPISpecValidationEngineError(res.status, res.statusText, body);
     }
 
     return (await res.json()) as OpenAPISpecValidationResult;
@@ -203,9 +228,7 @@ export class OpenAPISpecValidationService {
         res.statusText,
         body
       );
-      throw new OpenAPISpecValidationServiceUnavailableError(
-        `OAS validation service unavailable: ${res.status} ${res.statusText}`
-      );
+      throw new OpenAPISpecValidationEngineError(res.status, res.statusText, body);
     }
 
     const body = (await res.json()) as { versions?: string[] };
@@ -233,9 +256,7 @@ export class OpenAPISpecValidationService {
         res.statusText,
         body
       );
-      throw new OpenAPISpecValidationServiceUnavailableError(
-        `OAS validation service unavailable: ${res.status} ${res.statusText}`
-      );
+      throw new OpenAPISpecValidationEngineError(res.status, res.statusText, body);
     }
 
     const body = (await res.json()) as { rulesets?: string[] };

--- a/src/test/services/workflow/openapi-spec-validation-service.test.js
+++ b/src/test/services/workflow/openapi-spec-validation-service.test.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch');
 const {
   OpenAPISpecValidationError,
   OpenAPISpecValidationServiceUnavailableError,
+  OpenAPISpecValidationEngineError,
   OpenAPISpecValidationService,
 } = require('../../../services/workflow/openapi-spec-validation-service');
 
@@ -353,7 +354,7 @@ describe('OpenAPISpecValidationService', () => {
     );
   });
 
-  it('throws a service unavailable error when the validation service request fails', async () => {
+  it('throws a validation engine error (not a service-unavailable error) when the validation request itself is rejected', async () => {
     fetch.mockResolvedValue({
       ok: false,
       status: 404,
@@ -366,13 +367,18 @@ describe('OpenAPISpecValidationService', () => {
       'missing-version'
     );
 
+    await expect(service.validateRuleset('{}')).rejects.toBeInstanceOf(
+      OpenAPISpecValidationEngineError
+    );
     await expect(service.validateRuleset('{}')).rejects.toMatchObject({
-      name: 'OpenAPISpecValidationServiceUnavailableError',
-      message: 'OAS validation service unavailable: 404 Not Found',
+      name: 'OpenAPISpecValidationEngineError',
+      status: 404,
+      statusText: 'Not Found',
+      body: '{"error":"not_found"}',
     });
   });
 
-  it('throws a service unavailable error when the selected default ruleset is not found by the validation service', async () => {
+  it('throws a validation engine error (not a service-unavailable error) when the validation service rejects the posted spec', async () => {
     fetch
       .mockResolvedValueOnce({
         ok: true,
@@ -382,9 +388,9 @@ describe('OpenAPISpecValidationService', () => {
       })
       .mockResolvedValueOnce({
         ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        text: async () => '{"error":"ruleset_not_found"}',
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => '{"detail":"Spectral validation engine internal error"}',
       });
 
     const service = new OpenAPISpecValidationService(
@@ -393,8 +399,9 @@ describe('OpenAPISpecValidationService', () => {
     );
 
     await expect(service.validateRuleset('{}')).rejects.toMatchObject({
-      name: 'OpenAPISpecValidationServiceUnavailableError',
-      message: 'OAS validation service unavailable: 404 Not Found',
+      name: 'OpenAPISpecValidationEngineError',
+      status: 500,
+      statusText: 'Internal Server Error',
     });
     expect(fetch).toHaveBeenNthCalledWith(
       2,


### PR DESCRIPTION
## Summary

`openapi-spec-validation-service.ts`'s `createValidation` (and the sibling `getSupportedVersions`/`getSupportedRulesets`) mapped *every* non-2xx response from the OAS validator to `OpenAPISpecValidationServiceUnavailableError`, erasing the difference between an unreachable validator and a reachable one that rejected the request (a Spectral engine crash, a malformed-body 400, ...). Confirmed live: a spec triggering the validator's Spectral null-guard crash returns 500 and was reported to callers as "OAS validation service unavailable" — directing operators toward availability/network diagnostics for an engine-side problem.

Non-2xx validator responses now throw a new `OpenAPISpecValidationEngineError`, preserving the real status/statusText/body; `OpenAPISpecValidationServiceUnavailableError` is reserved for actual connectivity failures (timeouts/aborts, an empty supported-versions list). `api-openapi.js`'s error-mapping middleware reports the new error as `502 validation_engine_error` with the preserved diagnostic fields, instead of a generic `503`. Updates the two existing unit tests that asserted the old masked behavior.

## Test plan

- [x] `node e2e-sdx/run.js --test err-015` (from the paired harness PR #1506): before the fix, a spec crashing the validator's Spectral engine returned `503 validation_service_unavailable`. After rebuilding with this fix, the same spec now returns `502 validation_engine_error` with the real "Spectral validation engine internal error" body.
- [x] Updated `src/test/services/workflow/openapi-spec-validation-service.test.js`'s two tests that asserted the old masked behavior.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>