### PR TITLE
ERR-019: apply the SDX publication transform to OAD retrieval endpoints

### DIFF
--- a/src/controllers/sdx/v1/CatalogController.ts
+++ b/src/controllers/sdx/v1/CatalogController.ts
@@ -43,6 +43,7 @@ import {
 import { KeystoneService } from '../../ioc/keystoneInjector';
 import assert from 'assert';
 import { ResourceScope } from '../../../services/workflow/openapi-spec-loader';
+import { publishOpenApiSpec } from '../../../services/workflow/openapi-spec-publisher';
 
 interface MissingCredentialsJSON {
   code: 'credentials_required' | 'invalid_token';
@@ -310,6 +311,6 @@ export class CatalogController extends Controller {
   ): Promise<any> {
     const ctx = this.keystone.sudo();
     const entry = await GetCatalogByName(ctx, name, true);
-    return YAML.parse(entry.spec);
+    return publishOpenApiSpec(YAML.parse(entry.spec), entry);
   }
 }

--- a/src/controllers/sdx/v1/OrgServiceController.ts
+++ b/src/controllers/sdx/v1/OrgServiceController.ts
@@ -30,6 +30,7 @@ import {
   LoadOpenAPISpec,
   OpenAPISpecInput,
 } from '../../../services/workflow/openapi-spec-loader';
+import { publishOpenApiSpec } from '../../../services/workflow/openapi-spec-publisher';
 import { assertEqual, assertIsDefined } from '../../ioc/assert';
 import { KeystoneService } from '../../ioc/keystoneInjector';
 import { ExpressRequest } from './types';
@@ -212,7 +213,7 @@ export class GatewayServiceController extends Controller {
       'spec',
       'No OpenAPI specification found for this service'
     );
-    return YAML.parse(entry.spec);
+    return publishOpenApiSpec(YAML.parse(entry.spec), entry);
   }
 
   /**

--- a/src/services/workflow/openapi-spec-publisher.ts
+++ b/src/services/workflow/openapi-spec-publisher.ts
@@ -1,0 +1,47 @@
+import { ServiceCatalogEntry } from '../gateway-patterns/catalog';
+import { getRoutePathPrefix } from '../utils';
+
+/**
+ * ERR-019: the OAD retrieval endpoints (public catalog and
+ * organization-scoped) previously returned exactly the stored spec -
+ * validation-enriched (openapi-spec-loader.ts adds `x-csbc-api-standard`/
+ * `-ruleset`) but otherwise untouched, not the fully SDX-transformed
+ * publication artifact the SDX API Standard describes: environment-
+ * specific `servers`, no provider `info.contact`, and an SDX
+ * `externalDocs` entry. This applies that transform at *read* time,
+ * leaving the stored copy (what CatalogController/OrgServiceController
+ * read from) as the validation-enriched original - so "what was
+ * uploaded/validated" and "what's published" stay distinguishable.
+ *
+ * OAuth endpoint rewriting (the Standard also describes updating
+ * placeholder OAuth URLs) is intentionally not attempted here: unlike the
+ * route prefix below, there's no single already-established SDX
+ * convention in this codebase for deriving the correct per-service OAuth
+ * issuer, and guessing one would be worse than leaving the documented gap.
+ */
+export function publishOpenApiSpec(oas: any, entry: ServiceCatalogEntry): any {
+  const published = { ...oas, info: { ...oas.info } };
+  delete published.info.contact;
+
+  const clientId = entry.subsystem?.clientId;
+  if (clientId) {
+    const sdxPublicUrl = (
+      process.env.SDX_PUBLIC_URL || 'https://sdx.gov.bc.ca'
+    ).replace(/\/+$/, '');
+    published.servers = [
+      {
+        url: `${sdxPublicUrl}${getRoutePathPrefix(clientId)}`,
+        description: 'SDX-published endpoint',
+      },
+    ];
+  }
+
+  published.externalDocs = {
+    description: 'Secure Data Exchange (SDX) documentation',
+    url:
+      process.env.SDX_DOCS_URL ||
+      'https://developer.gov.bc.ca/docs/default/component/aps-guides/secure-data-exchange/',
+  };
+
+  return published;
+}


### PR DESCRIPTION
## Summary

Both the public catalog OAD endpoint (`CatalogController.getOASServiceSpec`) and the organization-scoped one (`GatewayServiceController.getOrganizationServiceSpec`) returned exactly the stored spec — validation-enriched (`x-csbc-api-standard`/`-ruleset`, added at upload time by `openapi-spec-loader.ts`) but otherwise untouched. The SDX API Standard describes a further publication transform: environment-specific `servers`, no provider `info.contact`, and an SDX `externalDocs` entry — none of which were applied, so the live Widget OAD still exposed its original `/api/v1` server and provider contact info with no SDX `externalDocs`.

Adds `openapi-spec-publisher.ts`'s `publishOpenApiSpec`, applied at *read* time (the stored copy is untouched, keeping "what was validated" and "what's published" distinguishable): strips `info.contact`, rewrites `servers` to the SDX-published endpoint using the same `/sdx/0/{clientId}` route convention already established in `services/utils.ts`, and adds `externalDocs` pointing at SDX documentation.

OAuth endpoint rewriting (also described by the Standard) is intentionally left as a documented gap — there's no established per-service convention for it in this codebase to build on, unlike the route prefix.

## Test plan

- [x] `node e2e-sdx/run.js --test err-019` (from the paired harness PR #1506): before the fix, a service registered with a distinctive `servers` URL and `info.contact` retained both unchanged on retrieval, with no `externalDocs`. After rebuilding with this fix, the retrieved spec no longer exposes the original `servers` URL or `info.contact`, and now carries an `externalDocs` entry alongside the pre-existing `x-csbc-api-standard` enrichment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>