### PR TITLE
ERR-020: require policyVersion when creating a connection request

### DIFF
--- a/src/services/batch/connection-service.ts
+++ b/src/services/batch/connection-service.ts
@@ -18,7 +18,7 @@ import { ConnectionRequestInput } from '../../controllers/sdx/v1/types';
 import { SubsystemService } from './subsystem';
 import { OpenAPISpecService } from './oas-service';
 import { strict as assert } from 'assert';
-import { assertEqual } from '../../controllers/ioc/assert';
+import { assertEqual, assertIsDefined } from '../../controllers/ioc/assert';
 import { ProvisionerService } from '../provisioner';
 
 const logger = Logger('batch.connection');
@@ -86,6 +86,33 @@ class ConnectionService {
         true,
         'clientId',
         'Only client subsystems can create connection requests for their own organization'
+      );
+    }
+
+    // policyVersion is only meaningful (and required) when *creating* a
+    // connection request - consumer-open/provider-open/approve/deactivate
+    // all reuse this same upsert endpoint to patch a single field on an
+    // already-created connection, and never send it. ERR-020: the DevHub
+    // example and the public schema both treat it as optional, but the
+    // provisioner requires it once a connection is activated, and the
+    // resulting failure was a generic create-failed with no indication
+    // policyVersion was the missing field.
+    const existing = await getRecords(
+      context,
+      'ConnectionRequest',
+      undefined,
+      [],
+      {
+        query: '$clientId: String, $serviceId: String',
+        clause: '{ clientId: $clientId, serviceId: $serviceId }',
+        variables: { clientId: body.clientId, serviceId: body.serviceId },
+      }
+    );
+    if (existing.length === 0) {
+      assertIsDefined(
+        body.policyVersion,
+        'policyVersion',
+        'policyVersion is required when creating a new connection request'
       );
     }
 


### PR DESCRIPTION
## Summary

`src/lists/ConnectionRequest.js` marks `policyVersion` required at the Keystone list layer, but the public controller/DTO layer (`ConnectionRequestInput.policyVersion`) treats it as optional — so omitting it wasn't caught until deep in the batch-create path, which only reported a generic `create-failed`/"invalid mutation" with no field-specific explanation.

`upsertConnection` is shared by create and every patch-style follow-up call (consumer-open, provider-open, approve, deactivate), so `policyVersion` can't be required unconditionally — only when no connection exists yet for the `clientId`/`serviceId` pair. `ConnectionService.upsertConnection` now checks for an existing connection first; if none exists (a create), `policyVersion` is required via a field-specific `ValidateError`.

## Test plan

- [x] `node e2e-sdx/run.js --test err-020` (from the paired harness PR #1506): before the fix, creating a connection without `policyVersion` returned a generic `400 create-failed`/"invalid mutation" with no field name. After rebuilding with this fix, the same request now returns `422` with `fields.policyVersion.message` naming the missing field.
- [x] `node e2e-sdx/run.js` (happy-path) confirmed no regression — all the update-style connection calls (which never send `policyVersion`) are unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>