### PR TITLE
ERR-023: populate the R0 requester even when requesterDetails is omitted

### DIFF
--- a/src/controllers/sdx/v1/OrgConnectionController.ts
+++ b/src/controllers/sdx/v1/OrgConnectionController.ts
@@ -58,11 +58,22 @@ export class OrgConnectionController extends Controller {
   ): Promise<BatchResult> {
     const ctx = this.keystone.createContext(request);
 
-    // For R0 policy, force the requester details to be the user making this request
-    if (input.policyVersion === 'SDX.R0.00' && input.requesterDetails) {
-      input.requesterDetails.requester = {
-        name: request.user.name,
-        email: request.user.email,
+    // For R0 policy, force the requester details to be the user making
+    // this request. ERR-023: previously only overwrote `requester` when
+    // the caller already sent a truthy `requesterDetails` object - an
+    // omitted `requesterDetails` (the documented DevHub example) instead
+    // fell through to ConnectionRequest.js's invalid persistence default
+    // ('{}'), which the SDX.R0.00 Cedar schema rejects at activation
+    // ("expected the record to have an attribute `requester`, but it does
+    // not"). Now populated unconditionally whenever this request declares
+    // the R0 policy, so the field is never left in that invalid shape.
+    if (input.policyVersion === 'SDX.R0.00') {
+      input.requesterDetails = {
+        ...(input.requesterDetails || {}),
+        requester: {
+          name: request.user.name,
+          email: request.user.email,
+        },
       };
     }
 


### PR DESCRIPTION
## Summary

`upsertConnection` only overwrote `requesterDetails.requester` with the authenticated caller's identity when the incoming mutation already contained a truthy `requesterDetails` object. Omitting it entirely (the documented DevHub example) instead let `ConnectionRequest.js`'s invalid persistence default (`'{}'`) through untouched — the `SDX.R0.00` Cedar context schema requires a nested `requester.name` whenever `requesterDetails` is present at all, so that default fails policy evaluation at activation with `"expected the record to have an attribute 'requester', but it does not"`, confirmed live in the provisioner logs.

Now populated unconditionally whenever `policyVersion` is `SDX.R0.00`, regardless of whether the caller sent `requesterDetails`.

## Test plan

- [x] `node e2e-sdx/run.js --test err-023` (from the paired harness PR #1506): before the fix, a connection created without `requesterDetails` activated with the provisioner logging a Cedar policy check failure ("expected the record to have an attribute `requester`, but it does not"). After rebuilding with this fix, the same connection now activates with the provisioner logging `"Policy check passed"`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>