### PR TITLE
ERR-024: await and propagate the provisioner call in postConnectionRequestChangeEvent

### DIFF
--- a/src/services/provisioner/provisioner-service.ts
+++ b/src/services/provisioner/provisioner-service.ts
@@ -92,7 +92,7 @@ export class ProvisionerService {
   public async postConnectionRequestChangeEvent(
     connection: ConnectionRequest,
     action: 'apply' | 'delete'
-  ): Promise<void> {
+  ): Promise<ConnectionRequestChangeEventResponse> {
     // credentials will be using the gwa admin
 
     const payload = {
@@ -113,7 +113,15 @@ export class ProvisionerService {
 
     const body = JSON.stringify(payload);
 
-    fetch(
+    // ERR-024: this fetch chain was previously not returned/awaited, so
+    // this method (despite being `async`) resolved as soon as the request
+    // was *started*, not when it completed - the afterChange hook's
+    // `await` on this call was therefore meaningless, and any provisioner
+    // failure was only ever logged, never surfaced to the caller. Now
+    // returned/re-thrown so the caller's existing `await` genuinely waits
+    // for the provisioner and a failure propagates instead of being
+    // swallowed.
+    return fetch(
       `${this.provisionerUrl}/connections/${connection.id}?action=${action}`,
       {
         method: 'POST',
@@ -133,10 +141,12 @@ export class ProvisionerService {
           r.failed,
           r
         );
+        return r;
       })
       .catch((err) => {
         logger.error('Provisioner Sent: %s', body);
         logger.error('Provisioner Error: %s', err);
+        throw err;
       });
   }
 


### PR DESCRIPTION
## Summary

`postConnectionRequestChangeEvent` was declared `async` returning `Promise<void>`, but its `fetch(...).then(...).then(...).catch(...)` chain was never returned or awaited — the method resolved as soon as the request was *started*, not when it completed, and any failure was only ever logged. Its sole caller, `ConnectionRequest.js`'s `afterChange` hook, already does `await provisionerService.postConnectionRequestChangeEvent(...)` — that await was meaningless against a promise that resolved early.

Confirmed live: setting `isActive: true` on a connection whose downstream policy evaluation then failed still returned HTTP 200/"updated" immediately, with the failure only visible ~2s later in the provider organization's activity feed.

Now returns/re-throws the fetch chain, so the existing `await` in the hook genuinely waits for the provisioner call and a failure propagates to the mutation response instead of being swallowed. Does **not** additionally populate `provisionerStatus` with pending/success/failed states (the errata's other suggested option) — doing that safely from this list's own `afterChange` hook needs a way to write back to the record without re-triggering the same hook, which this change doesn't add.

## Test plan

- [x] `node e2e-sdx/run.js --test err-024` (from the paired harness PR #1506): activates a connection submitted with `policyVersion: SDX.R1.00` without R1's required requester shape, so provisioning is guaranteed to fail independent of any other fix. Before this fix, the activation call returned `200 updated` regardless. After rebuilding with this fix, the same activation now returns `400 update-failed` with the provisioner's `500 Internal server error` reason.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>