### PR TITLE
ERR-025: add useSni to the R0 Cedar schema, fix mixed useSni/use_sni reads

### DIFF
--- a/provisioner-api/src/services/gateway-patterns/sdx-p2p-provider.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-p2p-provider.ts
@@ -171,7 +171,7 @@ export class SDXP2PProviderPattern implements PatternProcessor {
             headers: {
               'X-Client-Id': [`${clientLocator}`],
             },
-            protocols: inputs.use_sni === 'false' ? ['http'] : ['https'],
+            protocols: inputs.useSni === 'false' ? ['http'] : ['https'],
             strip_path: true,
           },
           {
@@ -184,7 +184,7 @@ export class SDXP2PProviderPattern implements PatternProcessor {
             headers: {
               'X-Client-Id': [`${clientLocator}`],
             },
-            protocols: inputs.use_sni === 'false' ? ['http'] : ['https'],
+            protocols: inputs.useSni === 'false' ? ['http'] : ['https'],
             plugins: [
               {
                 name: 'request-termination',

--- a/provisioner-api/src/services/policies/SDX.R0.00/schema.cedarschema
+++ b/provisioner-api/src/services/policies/SDX.R0.00/schema.cedarschema
@@ -65,6 +65,7 @@ namespace SDX {
                     gatewayPatterns?: {
                         "sdx-p2p-provider.r1": {
                             upstreamUrl: String,
+                            useSni?: String,
                             upgrades: {
                                 mtlsAuth?: {},
                                 mtlsAcl?: {},


### PR DESCRIPTION
## Summary

`sdx-p2p-provider.ts` declares and reads a `useSni` string parameter, but the `SDX.R0.00` Cedar context schema's provider pattern record only defined `upstreamUrl`/`upgrades` — activating a connection with `useSni` set failed context validation with `"record attribute 'useSni' should not exist according to the schema"` (confirmed live in the provisioner logs), even though the schema treats unknown record fields as invalid rather than ignoring them.

Separately, the route/protocol generation itself only partially honored `useSni`: `snis` correctly read `inputs.useSni`, but `protocols` on both generated routes read the nonexistent `inputs.use_sni` (always `undefined`), so `useSni: "false"` disabled SNI but left the protocol forced to `https` regardless.

## Test plan

- [x] `node e2e-sdx/run.js --test err-025` (from the paired harness PR #1506): before the fix, activating a connection with `useSni: "true"` on the provider pattern failed Cedar context validation. After rebuilding with this fix, the same connection now provisions successfully end-to-end (Kong routes/plugins created, "Sync successful" from GWA).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>