### PR TITLE
ERR-018: relax the subsystem route allow-list instead of an unmatched prefix

### DIFF
--- a/src/controllers/sdx/v1/OrgSubsystemController.ts
+++ b/src/controllers/sdx/v1/OrgSubsystemController.ts
@@ -30,7 +30,6 @@ import {
   replaceKey,
   transformAllRefID,
 } from '../../../batch/feed-worker';
-import { getRoutePathPrefix } from '../../../services/utils';
 
 @injectable()
 @Route('/organizations/{org}/subsystems')
@@ -167,12 +166,20 @@ export class OrgSubsystemController extends Controller {
 
     const client = GetSubsystemEntryForSubsystem(subsystem);
 
-    const routePathPrefix = getRoutePathPrefix(client.clientId);
-
+    // ERR-018: this namespace's perm-route-paths allow-list previously
+    // scoped to a synthetic /sdx/0/{clientId} prefix (getRoutePathPrefix)
+    // that no generated service-pattern route (sdx-service.r1's Kong
+    // routes come straight from the OAS operation paths, unprefixed) ever
+    // actually matched - the two were generated from unrelated
+    // conventions. The runtime group and its hosted services aren't known
+    // yet at subsystem-registration time, so there's no set of concrete
+    // operation paths to scope this to in advance either. Permit any path
+    // under this namespace instead of a prefix that nothing published
+    // here would ever satisfy.
     const result = await CreateNamespaceForSubsystem(context, {
       subsystem: client,
       runtimeGroupName: body.runtimeGroupName,
-      routePaths: [routePathPrefix],
+      routePaths: ['/'],
     });
 
     assertEqual(


### PR DESCRIPTION
## Summary

`registerSubsystemGateway` scoped each namespace's `perm-route-paths` allow-list to a synthetic `/sdx/0/{clientId}` prefix (`getRoutePathPrefix`), but `provisioner-api`'s `sdx-service.r1` generates Kong route paths straight from each OAS operation's path with no such prefix — the two were built from unrelated conventions and never matched. This currently isn't a live publication blocker only because `enforce-route-paths` is off; turning it on would break every SDX service publication of this shape.

**Decided direction** (team decision, not a unilateral call): relax the allow-list rather than prefix every generated service route. The runtime group and its hosted services aren't known yet at subsystem-registration time, so there's no concrete set of operation paths to scope the allow-list to in advance — prefixing routes instead would need Kong `strip_path`/prefix-match changes verified against a real Kong instance, which felt riskier to ship without that verification. The namespace now registers `perm-route-paths: ['/']` instead of the synthetic prefix.

Also updates `e2e-sdx`'s `err-018.js` scenario (on the base branch, #1506): since there's no public API to read a namespace's `perm-route-paths` attribute back, it now checks the local docker-compose `apsportal` container's own debug logs for the registered value.

## Test plan

- [x] `node e2e-sdx/run.js --test err-018` (from the paired harness PR #1506): before the fix, the namespace registered `perm-route-paths: ["/sdx/0/{clientId}"]`, which none of the previewed service routes (`/hello`, `/ping`) matched. After rebuilding with this fix, the namespace now registers `perm-route-paths: ["/"]`, which is compatible with whatever paths a service's OAS operations actually publish.
- [x] `node e2e-sdx/run.js` (happy-path) confirmed no regression.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>