### PR TITLE
ENH-001: return RBAC roles via includeAccess on /catalog/organizations

### DIFF
--- a/e2e-sdx/README.md
+++ b/e2e-sdx/README.md
@@ -127,6 +127,7 @@ against anything shared.
 | `err-025` | The R0 policy schema rejects the implemented `useSni` provider parameter |
 | `err-029` | OAS per-operation security scopes aren't converted into runtime enforcement |
 | `err-032` | A provider `serviceResources` update reports `no-change` despite persisting (not reliably reproduced locally - see the file's header comment) |
+| `enh-001` | `/catalog/organizations` has no `includeAccess` parameter to return RBAC role membership, unlike the subsystem catalog (requires `--member-email` set to a real local user - see the file's header comment) |
 
 `err-031` (updating an existing integration connection crashes the
 provisioner) is **not yet implemented** as a live scenario: reproducing it

--- a/e2e-sdx/lib/steps/org.js
+++ b/e2e-sdx/lib/steps/org.js
@@ -97,4 +97,31 @@ function orgGateway(ctx, overrides = {}) {
   };
 }
 
-module.exports = { ROOT_ORG_DOMAIN, createOrg, orgAccess, orgGateway };
+/**
+ * "List organizations in the catalog" (organization-list). ENH-001.
+ *
+ * Pass `overrides.includeAccess: true` to add `--include-access`, which
+ * enriches each organization entry with its RBAC role membership.
+ */
+function listOrganizations(ctx, overrides = {}) {
+  const { state } = ctx;
+  return {
+    id: overrides.id || 'org.list',
+    title: overrides.title || 'List organizations',
+    fatal: overrides.fatal !== undefined ? overrides.fatal : false,
+    run: async () => {
+      const args = ['organization-list'];
+      if (overrides.includeAccess) args.push('--include-access');
+      const res = await ctx.call(overrides.id || 'org.list', state.sdxAlias, args);
+      if (overrides.onResult) await overrides.onResult(res, ctx);
+    },
+  };
+}
+
+module.exports = {
+  ROOT_ORG_DOMAIN,
+  createOrg,
+  orgAccess,
+  orgGateway,
+  listOrganizations,
+};

--- a/e2e-sdx/run.js
+++ b/e2e-sdx/run.js
@@ -20,6 +20,7 @@ const tests = {
   'err-029': () => require('./tests/err-029'),
   // 'err-031' - not yet implemented, see README.md's "Error scenarios" section.
   'err-032': () => require('./tests/err-032'),
+  'enh-001': () => require('./tests/enh-001'),
 };
 
 engine.main({ tests, argv: process.argv.slice(2) }).catch((err) => {

--- a/e2e-sdx/tests/enh-001.js
+++ b/e2e-sdx/tests/enh-001.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * ENH-001 - Return roles as an optional query parameter on
+ * /catalog/organizations, matching the existing subsystem-side pattern
+ * (getSubsystem's includeAccess, and "Subsystem Clients" which does this
+ * unconditionally).
+ *
+ * Design decision (confirmed, not an oversight): includeAccess does NOT
+ * require an authenticated caller - role membership is read from Keycloak
+ * using the portal's own service credentials, the same way
+ * getSubsystemRoles already resolves subsystem access. This harness always
+ * calls through an authenticated restish profile, so it can't separately
+ * exercise "works with zero auth" locally - it verifies the functional
+ * behavior instead (the right organization gets its actual role membership
+ * back).
+ *
+ * Requires a real, resolvable local Keycloak user for `--member-email` (the
+ * default generated `sdx-test-<id>@example.gov.bc.ca` address matches no
+ * real user, so `put-organization-access` warns "No suitable match" and
+ * grants nothing - see `local/keycloak/master-realm.json`'s seeded `@idir`
+ * users, e.g. `wendy@test.com`):
+ *
+ *   node run.js --test enh-001 --member-email wendy@test.com
+ */
+
+const org = require('../lib/steps/org');
+
+function buildSteps(ctx) {
+  const { state } = ctx;
+  const td = state.testData;
+
+  return [
+    org.createOrg(ctx),
+    org.orgAccess(ctx), // grants state.memberEmail 'system-admin' by default
+
+    org.listOrganizations(ctx, {
+      id: 'org.list.plain',
+      title: 'List organizations (no includeAccess)',
+      onResult: (res) => {
+        const entries = res.json || [];
+        const mine = entries.find((o) => o.name === td.orgName);
+        if (!mine) {
+          console.log(
+            `UNEXPECTED [ENH-001]: ${td.orgName} not found in organization-list.`
+          );
+        } else if (mine.access !== undefined) {
+          console.log(
+            'UNEXPECTED [ENH-001]: organization-list included "access" even without --include-access.'
+          );
+        } else {
+          console.log(
+            'OK [ENH-001]: organization-list without --include-access is unchanged (no "access" field).'
+          );
+        }
+      },
+    }),
+
+    org.listOrganizations(ctx, {
+      id: 'org.list.access',
+      title: 'List organizations (--include-access)',
+      includeAccess: true,
+      onResult: (res) => {
+        const entries = res.json || [];
+        const mine = entries.find((o) => o.name === td.orgName);
+        if (!mine) {
+          console.log(
+            `UNEXPECTED [ENH-001]: ${td.orgName} not found in organization-list.`
+          );
+          return;
+        }
+        const access = mine.access || [];
+        const match = access.find(
+          (m) => m.member && m.member.email === state.memberEmail
+        );
+        if (!match) {
+          console.log(
+            `CONFIRMED [ENH-001]: organization-list --include-access did not return role membership for ` +
+              `${state.memberEmail} on ${td.orgName} - either the parameter does not exist yet, or the ` +
+              `member was not resolved (check --member-email is a real local user, e.g. wendy@test.com).`
+          );
+        } else if (match.roles.includes('system-admin')) {
+          console.log(
+            `RESOLVED [ENH-001]: organization-list --include-access returned ${state.memberEmail} with ` +
+              `roles [${match.roles.join(', ')}] for ${td.orgName}.`
+          );
+        } else {
+          console.log(
+            `UNEXPECTED [ENH-001]: ${state.memberEmail} found but without 'system-admin' - roles: ` +
+              `[${match.roles.join(', ')}].`
+          );
+        }
+      },
+    }),
+  ];
+}
+
+module.exports = { buildSteps };

--- a/src/controllers/sdx/v1/CatalogController.ts
+++ b/src/controllers/sdx/v1/CatalogController.ts
@@ -40,6 +40,7 @@ import {
   getOrganizationMemberDetails,
   getOrganizations,
 } from '../../../services/keystone/organization';
+import { getOrganizationRoles } from '../../../services/workflow/get-organization-roles';
 import { KeystoneService } from '../../ioc/keystoneInjector';
 import assert from 'assert';
 import { ResourceScope } from '../../../services/workflow/openapi-spec-loader';
@@ -92,11 +93,25 @@ export class CatalogController extends Controller {
       .map((o) => parseBlobString(o));
   }
 
+  /**
+   * Retrieve the list of organizations available in the SDX catalog.
+   *
+   * `includeAccess` does not require an authenticated caller - RBAC role
+   * membership is read directly from Keycloak using the portal's own
+   * service credentials, the same way subsystem `access` is already
+   * resolved for `/catalog/subsystems/{name}?includeAccess=true`.
+   *
+   * @summary List organizations in the catalog
+   * @param includeAccess - When true, include each organization's RBAC role membership
+   */
   @Get('/organizations')
   @OperationId('organization-list')
-  public async listOrganizations(): Promise<any[]> {
-    const orgs = await getOrganizations(this.keystone.sudo());
-    return orgs
+  public async listOrganizations(
+    @Query('includeAccess') includeAccess: boolean = false
+  ): Promise<any[]> {
+    const ctx = this.keystone.sudo();
+    const orgs = await getOrganizations(ctx);
+    const entries = orgs
       .map((o) => ({
         name: o.name,
         title: o.title,
@@ -104,8 +119,17 @@ export class CatalogController extends Controller {
         publicBodyId: o.publicBodyId,
         member: getOrganizationMemberDetails(o.tags),
       }))
-      .filter((o) => o.member !== undefined)
-      .map((o) => removeEmpty(o));
+      .filter((o) => o.member !== undefined);
+
+    if (includeAccess) {
+      await Promise.all(
+        entries.map(async (o: any) => {
+          o.access = await getOrganizationRoles(ctx, o.name);
+        })
+      );
+    }
+
+    return entries.map((o) => removeEmpty(o));
   }
 
   /**

--- a/src/services/workflow/get-organization-roles.ts
+++ b/src/services/workflow/get-organization-roles.ts
@@ -1,0 +1,47 @@
+import { lookupProductEnvironmentServicesBySlug } from '../keystone';
+import { getEnvironmentContext } from './get-namespaces';
+
+import { Logger } from '../../logger';
+import { GroupAccessService } from '../org-groups';
+import type { GroupMember } from '../org-groups/types';
+import { removeKeys } from '../../batch/feed-worker';
+
+const logger = Logger('get-organization-roles');
+
+/**
+ * Reads organization-level RBAC role membership (organization-admin,
+ * system-admin, ...) directly from Keycloak, using the portal's own service
+ * credentials - not the caller's token. Mirrors `getSubsystemRoles`, which
+ * already reads subsystem role membership the same way for the SDX catalog.
+ */
+export async function getOrganizationRoles(
+  context: any,
+  orgName: string
+): Promise<GroupMember[] | undefined> {
+  logger.debug('Getting organization roles for %s', orgName);
+
+  const prodEnv = await lookupProductEnvironmentServicesBySlug(
+    context,
+    process.env.GWA_PROD_ENV_SLUG!
+  );
+  const envCtx = await getEnvironmentContext(context, prodEnv.id, {}, false);
+
+  const kc = new GroupAccessService(envCtx.uma2);
+
+  await kc.login(
+    envCtx.issuerEnvConfig.clientId!,
+    envCtx.issuerEnvConfig.clientSecret!
+  );
+
+  const result = await kc.getGroupMembership(orgName);
+  if (result) {
+    return removeKeys(result.members as GroupMember[], [
+      'id',
+      'username',
+    ]) as GroupMember[];
+  }
+
+  logger.debug('Group membership not found for %s', orgName);
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- `/catalog/organizations` (`organization-list`) had no way to surface an organization's RBAC role membership, unlike the subsystem side of the same catalog: `getSubsystem`'s `includeAccess` query parameter, and "Subsystem Clients" (`OrgSubsystemClientController`), both already expose `access: GroupMember[]` via `EnrichWithAccess`/`getSubsystemRoles`.
- The organization-level read already existed - just on the internal v3 API (`OrganizationController.get`, `GET /organizations/{org}/access`, `GroupAccess.Manage`), not reachable through the SDX partner-facing `sdx` Restish alias.
- Adds an optional `includeAccess` boolean query parameter to `listOrganizations`; when set, calls the same `GroupAccessService.getGroupMembership(org.name)` primitive per organization and attaches the result as `access`.
- **Design decision** (confirmed, not an oversight): `includeAccess` does **not** require an authenticated caller. `/catalog/organizations` stays fully public exactly as it is today; the lookup is resolved via the portal's own Keycloak service-account credentials (same pattern `getSubsystemRoles` already uses), not the caller's token - meaning organization role members' names/emails become visible to anonymous callers when the parameter is passed. See `feedback/DOCUMENTATION-ERRATA-OUTSTANDING-r1.md`'s ENH-001 entry for the full write-up.

## Test plan

- [x] New e2e-sdx demonstration scenario `tests/enh-001.js` (`node run.js --test enh-001 --member-email <a real local user, e.g. wendy@test.com>`).
- [x] Pre-fix: `CONFIRMED` - restish rejects the unknown `--include-access` flag.
- [x] Post-fix: `RESOLVED` - `organization-list --include-access` returns the granted member with `system-admin` for the target org; the unparameterized call is unchanged (no `access` field).
- [x] Full `happy-path.js` regression run passes end-to-end.
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)