### PR TITLE
ENH-002: expose subsystem RBAC access change via GET/PUT .../access

### DIFF
--- a/e2e-sdx/README.md
+++ b/e2e-sdx/README.md
@@ -127,6 +127,7 @@ against anything shared.
 | `err-025` | The R0 policy schema rejects the implemented `useSni` provider parameter |
 | `err-029` | OAS per-operation security scopes aren't converted into runtime enforcement |
 | `err-032` | A provider `serviceResources` update reports `no-change` despite persisting (not reliably reproduced locally - see the file's header comment) |
+| `enh-002` | No supported operation to change a subsystem's RBAC role membership (System Owner / Access Manager / Tech Lead) after registration |
 
 `err-031` (updating an existing integration connection crashes the
 provisioner) is **not yet implemented** as a live scenario: reproducing it

--- a/e2e-sdx/lib/steps/subsystem.js
+++ b/e2e-sdx/lib/steps/subsystem.js
@@ -98,9 +98,60 @@ function verifySubsystemClient(ctx, overrides = {}) {
   };
 }
 
+/**
+ * "Retrieve RBAC role membership for a subsystem" (get-subsystem-access).
+ * ENH-002.
+ */
+function getSubsystemAccess(ctx, overrides = {}) {
+  const { state } = ctx;
+  const td = state.testData;
+  return {
+    id: overrides.id || 'subsystem.access.get',
+    title: 'Get subsystem RBAC role membership',
+    fatal: overrides.fatal !== undefined ? overrides.fatal : false,
+    run: async () => {
+      const res = await ctx.call(
+        overrides.id || 'subsystem.access.get',
+        state.sdxAlias,
+        ['get-subsystem-access', td.orgName, td.subsystemName]
+      );
+      if (overrides.onResult) await overrides.onResult(res, ctx);
+    },
+  };
+}
+
+/**
+ * "Change RBAC role membership for a subsystem" (put-subsystem-access).
+ * ENH-002. `overrides.members` is a static `GroupMember[]` body known at
+ * build time; scenarios needing a body built from a previous step's
+ * captured result (e.g. the member reference `get-subsystem-access`
+ * returned) should call `ctx.call('put-subsystem-access', ...)` directly
+ * instead, inside a custom step's `run`.
+ */
+function putSubsystemAccess(ctx, overrides = {}) {
+  const { state } = ctx;
+  const td = state.testData;
+  return {
+    id: overrides.id || 'subsystem.access.put',
+    title: 'Change subsystem RBAC role membership',
+    fatal: overrides.fatal !== undefined ? overrides.fatal : false,
+    run: async () => {
+      const res = await ctx.call(
+        overrides.id || 'subsystem.access.put',
+        state.sdxAlias,
+        ['put-subsystem-access', td.orgName, td.subsystemName],
+        { body: { members: overrides.members || [] } }
+      );
+      if (overrides.onResult) await overrides.onResult(res, ctx);
+    },
+  };
+}
+
 module.exports = {
   createSubsystem,
   listAvailableRuntimeGroups,
   subsystemGateway,
   verifySubsystemClient,
+  getSubsystemAccess,
+  putSubsystemAccess,
 };

--- a/e2e-sdx/run.js
+++ b/e2e-sdx/run.js
@@ -20,6 +20,7 @@ const tests = {
   'err-029': () => require('./tests/err-029'),
   // 'err-031' - not yet implemented, see README.md's "Error scenarios" section.
   'err-032': () => require('./tests/err-032'),
+  'enh-002': () => require('./tests/enh-002'),
 };
 
 engine.main({ tests, argv: process.argv.slice(2) }).catch((err) => {

--- a/e2e-sdx/tests/enh-002.js
+++ b/e2e-sdx/tests/enh-002.js
@@ -1,0 +1,173 @@
+'use strict';
+
+/**
+ * ENH-002 - Ability to change RBAC role membership for a subsystem
+ * (System Owner / Access Manager / Tech Lead).
+ *
+ * The write primitive (SysGroupAccessService.createOrUpdateGroupAccess)
+ * already existed and already supports granting *and* revoking members in
+ * one sync call - it was only ever invoked once, internally, to bootstrap
+ * the subsystem creator's own three roles at registration time. This adds
+ * GET/PUT /organizations/{org}/subsystems/{name}/access to expose it, plus
+ * up-front role-name validation (porting PLAT-001's fix forward - the
+ * underlying write primitive still only *filters* unsupported role names
+ * instead of rejecting them).
+ *
+ * The local stack only has one real authenticated identity available (the
+ * restish caller itself, already granted all three roles when
+ * `subsystem.gateway` ran), so rather than inventing a second, unverifiable
+ * synthetic member, this scenario does a self-consistent round trip: read
+ * the caller's own access record back, submit an unsupported role for that
+ * same member (expect a field-specific 4xx), then resubmit the member with
+ * `access-manager` dropped and verify the sync actually revoked it while
+ * leaving `system-owner`/`tech-lead` intact.
+ */
+
+const { setupSubsystem } = require('../lib/steps/scenario-helpers');
+const subsystem = require('../lib/steps/subsystem');
+
+const ALL_ROLES = ['system-owner', 'tech-lead', 'access-manager'];
+
+function findMemberWithRoles(members) {
+  return (members || []).find((m) => m.roles && m.roles.length > 0);
+}
+
+function buildSteps(ctx) {
+  const { state } = ctx;
+  const td = state.testData;
+
+  return [
+    ...setupSubsystem(ctx),
+
+    subsystem.getSubsystemAccess(ctx, {
+      id: 'access.get.before',
+      onResult: (res) => {
+        const members = res.json || [];
+        const withRoles = findMemberWithRoles(members);
+        if (!withRoles) {
+          console.log(
+            'CONFIRMED [ENH-002]: get-subsystem-access returned no role members for a ' +
+              'just-registered subsystem - either the operation does not exist yet, or the ' +
+              'bootstrap grant at registration is not visible through it.'
+          );
+          return;
+        }
+        const roles = new Set(withRoles.roles);
+        const hasAll = ALL_ROLES.every((r) => roles.has(r));
+        console.log(
+          hasAll
+            ? 'RESOLVED [ENH-002]: get-subsystem-access returned the registering caller with all three bootstrap roles.'
+            : `UNEXPECTED [ENH-002]: caller has roles [${[...roles].join(', ')}], expected all three bootstrap roles.`
+        );
+        // Identify the member by email only - getSubsystemRoles's Keycloak
+        // read also returns a `name` field that the write side's UserReference
+        // schema doesn't declare, so blindly echoing the full read-model back
+        // as a write body gets rejected as an excess property. A real caller
+        // should identify members explicitly anyway, not round-trip a read
+        // model.
+        state.captured.subsystemAccessMember = { email: withRoles.member.email };
+        state.captured.subsystemAccessBefore = members;
+      },
+    }),
+
+    {
+      id: 'access.put.invalid-role',
+      title: 'Reject an unsupported role on subsystem access (ports PLAT-001 forward)',
+      fatal: false,
+      run: async () => {
+        if (!state.captured.subsystemAccessMember) {
+          console.log(
+            'SKIP [ENH-002]: no captured member from access.get.before - cannot test invalid-role validation.'
+          );
+          return;
+        }
+        try {
+          await ctx.call(
+            'access.put.invalid-role',
+            state.sdxAlias,
+            ['put-subsystem-access', td.orgName, td.subsystemName],
+            {
+              body: {
+                members: [
+                  {
+                    member: state.captured.subsystemAccessMember,
+                    roles: ['not-a-real-role'],
+                  },
+                ],
+              },
+            }
+          );
+          console.log(
+            'UNEXPECTED [ENH-002]: put-subsystem-access accepted an unsupported role name - ' +
+              "PLAT-001's validation was not ported forward to the subsystem-access write path."
+          );
+        } catch (err) {
+          console.log(
+            `RESOLVED [ENH-002]: put-subsystem-access rejected an unsupported role: ${err.message}`
+          );
+        }
+      },
+    },
+
+    {
+      id: 'access.put.revoke',
+      title: 'Drop access-manager for the captured member (sync/revoke)',
+      fatal: false,
+      run: async () => {
+        if (!state.captured.subsystemAccessMember) {
+          console.log(
+            'SKIP [ENH-002]: no captured member from access.get.before - cannot test revocation.'
+          );
+          return;
+        }
+        try {
+          await ctx.call(
+            'access.put.revoke',
+            state.sdxAlias,
+            ['put-subsystem-access', td.orgName, td.subsystemName],
+            {
+              body: {
+                members: [
+                  {
+                    member: state.captured.subsystemAccessMember,
+                    roles: ['system-owner', 'tech-lead'],
+                  },
+                ],
+              },
+            }
+          );
+        } catch (err) {
+          console.log(
+            `CONFIRMED [ENH-002]: put-subsystem-access is not available (${err.message}) - no supported way to change subsystem RBAC membership.`
+          );
+        }
+      },
+    },
+
+    subsystem.getSubsystemAccess(ctx, {
+      id: 'access.get.after',
+      onResult: (res) => {
+        if (!state.captured.subsystemAccessMember) return;
+        const members = res.json || [];
+        const after = findMemberWithRoles(members);
+        if (!after) {
+          console.log(
+            'UNEXPECTED [ENH-002]: no role members found after the revoke call.'
+          );
+          return;
+        }
+        const roles = new Set(after.roles);
+        const stillHasBoth =
+          roles.has('system-owner') && roles.has('tech-lead');
+        const revoked = !roles.has('access-manager');
+        console.log(
+          stillHasBoth && revoked
+            ? 'RESOLVED [ENH-002]: put-subsystem-access synced membership - access-manager revoked, system-owner/tech-lead retained.'
+            : `UNEXPECTED [ENH-002]: post-revoke roles are [${[...roles].join(', ')}] (expected system-owner+tech-lead, no access-manager).`
+        );
+      },
+    }),
+  ];
+}
+
+module.exports = { buildSteps };

--- a/src/controllers/sdx/v1/OrgSubsystemController.ts
+++ b/src/controllers/sdx/v1/OrgSubsystemController.ts
@@ -21,6 +21,10 @@ import {
   SubsystemEntry,
 } from '../../../services/gateway-patterns/catalog';
 import { CreateNamespaceForSubsystem } from '../../../services/workflow/create-namespace-sdx';
+import { getSubsystemRoles } from '../../../services/workflow/get-subsystem-roles';
+import { putSubsystemAccess as putSubsystemAccessWorkflow } from '../../../services/workflow/put-subsystem-access';
+import { SystemRoles } from '../../../services/org-groups/sys-group-access';
+import { GroupMember } from '../../../services/org-groups/types';
 import { assertEqual } from '../../ioc/assert';
 import { KeystoneService } from '../../ioc/keystoneInjector';
 import { SubsystemInput } from './types';
@@ -183,5 +187,81 @@ export class OrgSubsystemController extends Controller {
     );
 
     return { gatewayId: client.gateway!.id };
+  }
+
+  /**
+   * Retrieves RBAC role membership (System Owner, Tech Lead, Access Manager)
+   * for the specified subsystem.
+   *
+   * > `Required Scope:` System.Manage
+   *
+   * @summary Retrieve RBAC role membership for a subsystem
+   *
+   * @param org - Organization identifier
+   * @param name - Subsystem name
+   * @param request - HTTP request object for context creation
+   */
+  @Get('/{name}/access')
+  @OperationId('getSubsystemAccess')
+  @Security('jwt', ['System.Manage'])
+  public async getSubsystemAccess(
+    @Path() org: string,
+    @Path() name: string,
+    @Request() request: any
+  ): Promise<GroupMember[]> {
+    const ctx = this.keystone.createContext(request);
+
+    const subsysService = new SubsystemService();
+    const subsystem = await subsysService.findSubsystemByName(ctx, org, name);
+    const client = GetSubsystemEntryForSubsystem(subsystem);
+
+    return (await getSubsystemRoles(ctx, client.clientId)) ?? [];
+  }
+
+  /**
+   * Changes RBAC role membership (System Owner, Tech Lead, Access Manager)
+   * for the specified subsystem. This is a full sync: members omitted from
+   * `members` are removed from any of these roles they currently hold, and
+   * members included are granted exactly the roles listed.
+   *
+   * > `Required Scope:` System.Manage
+   *
+   * @summary Change RBAC role membership for a subsystem
+   *
+   * @param org - Organization identifier
+   * @param name - Subsystem name
+   * @param body - The complete desired set of role members
+   * @param request - HTTP request object for context creation
+   */
+  @Put('/{name}/access')
+  @OperationId('putSubsystemAccess')
+  @Security('jwt', ['System.Manage'])
+  public async putSubsystemAccess(
+    @Path() org: string,
+    @Path() name: string,
+    @Body() body: { members: GroupMember[] },
+    @Request() request: any
+  ): Promise<void> {
+    const allRoles: string[] = body.members.reduce(
+      (acc: string[], m: GroupMember) => acc.concat(m.roles),
+      []
+    );
+    const unsupported = [
+      ...new Set(allRoles.filter((r) => !SystemRoles.includes(r))),
+    ];
+    assertEqual(
+      unsupported.length === 0,
+      true,
+      'members',
+      `Unsupported role(s): ${unsupported.join(', ')}. Supported roles: ${SystemRoles.join(', ')}`
+    );
+
+    const ctx = this.keystone.createContext(request, true);
+
+    const subsysService = new SubsystemService();
+    const subsystem = await subsysService.findSubsystemByName(ctx, org, name);
+    const client = GetSubsystemEntryForSubsystem(subsystem);
+
+    await putSubsystemAccessWorkflow(ctx, client.clientId, body.members);
   }
 }

--- a/src/services/workflow/put-subsystem-access.ts
+++ b/src/services/workflow/put-subsystem-access.ts
@@ -1,0 +1,50 @@
+import { Logger } from '../../logger';
+import { lookupProductEnvironmentServicesBySlug } from '../keystone';
+import { getEnvironmentContext } from './get-namespaces';
+import { SysGroupAccessService } from '../org-groups/sys-group-access';
+import type { GroupMember } from '../org-groups/types';
+
+const logger = Logger('wf.put-subsystem-access');
+
+/**
+ * Grants/revokes subsystem RBAC role membership (system-owner, tech-lead,
+ * access-manager) by syncing the supplied member list against Keycloak.
+ *
+ * This is the same write primitive `create-namespace-sdx.ts`'s
+ * `prepareRoleAssignments` already uses once, internally, to bootstrap a
+ * subsystem's creator with all three roles at registration time - exposed
+ * here so RBAC membership can be changed afterward too.
+ */
+export async function putSubsystemAccess(
+  context: any,
+  subsystemId: string,
+  members: GroupMember[]
+): Promise<{
+  granted: Record<string, string[]>;
+  revoked: Record<string, string[]>;
+}> {
+  const noauthContext = context.createContext({ skipAccessControl: true });
+  const prodEnv = await lookupProductEnvironmentServicesBySlug(
+    noauthContext,
+    process.env.GWA_PROD_ENV_SLUG!
+  );
+  const envCtx = await getEnvironmentContext(context, prodEnv.id, {}, true);
+
+  const sga = new SysGroupAccessService(envCtx.uma2);
+  await sga.login(
+    envCtx.issuerEnvConfig.clientId!,
+    envCtx.issuerEnvConfig.clientSecret!
+  );
+
+  logger.debug(
+    'Updating subsystem access for %s: %o',
+    subsystemId,
+    members
+  );
+
+  return sga.createOrUpdateGroupAccess(
+    'subsystem',
+    { name: subsystemId, parent: '/systems', members },
+    ['idir']
+  );
+}


### PR DESCRIPTION
## Summary

- A subsystem's creator is granted `system-owner`/`tech-lead`/`access-manager` once, at registration (`create-namespace-sdx.ts`'s `prepareRoleAssignments`), via `SysGroupAccessService.createOrUpdateGroupAccess('subsystem', ...)`. That write primitive already fully supports granting *and* revoking membership in one sync call - it was just never invoked again afterward, so there was no supported way to add a colleague, hand off `system-owner`, or revoke access later (the same class of gap ERR-011/ERR-030 already found elsewhere in the platform).
- Adds `GET`/`PUT /organizations/{org}/subsystems/{name}/access` to `OrgSubsystemController`, delegating to that same write primitive and the existing `getSubsystemRoles` read.
- The write path validates every submitted role name against the exported `SystemRoles` list up front and rejects unsupported ones with a field-specific 4xx (`ValidateError`) - porting PLAT-001's fix forward, since the underlying `SysGroupAccessService.createOrUpdateGroupAccess` still only *filters* unsupported roles (`.filter(...)`) rather than rejecting them, same as `group-access.ts`'s org-level method did before PLAT-001.
- See `feedback/DOCUMENTATION-ERRATA-OUTSTANDING-r1.md`'s ENH-002 entry for the full write-up.

## Test plan

- [x] New e2e-sdx demonstration scenario `tests/enh-002.js` (`node run.js --test enh-002`).
- [x] Pre-fix: `CONFIRMED` - `get-subsystem-access`/`put-subsystem-access` don't exist yet.
- [x] Post-fix: `RESOLVED` on all three checks - reads back the registering caller's bootstrap roles; rejects an unsupported role name with a field-specific validation error; a role-drop sync correctly revokes `access-manager` while retaining `system-owner`/`tech-lead`.
- [x] Full `happy-path.js` regression run passes end-to-end.
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)