### PR TITLE
Fix racy stacked @Security OR in sdx/v1 auth

### DIFF
--- a/docs/sdx-v1-permissions-audit.md
+++ b/docs/sdx-v1-permissions-audit.md
@@ -186,6 +186,48 @@ applies to the current request:
 If none of the above resolves (the list case for either endpoint), the request falls through to
 the discovery-based check described next rather than being rejected outright.
 
+### Deterministic scope OR (`System.Manage` **or** `Subsystem.Manage`/`Connection.Manage`)
+
+Every endpoint above that accepts more than one scope declares them as a **single**
+`@Security('jwt', [scopeA, scopeB])` decorator with a multi-element scopes array (e.g.
+`@Security('jwt', ['System.Manage', 'Subsystem.Manage'])` on `createOASService`/`delete`), not
+multiple stacked `@Security(...)` decorators. This matters because of how tsoa's generated
+`authenticateMiddleware` (`src/controllers/sdx/v1/routes.ts`) handles the two cases differently:
+
+- **Stacked decorators** (multiple separate `@Security(...)` calls on one method) each become an
+  independent call to `expressAuthentication`, and tsoa fires all of them **concurrently**,
+  taking whichever fulfills first via the `promise.any` polyfill — correct for the pass/fail
+  decision itself (`promise.any` does correctly implement "resolve on first fulfillment, reject
+  only if all reject"), but the concurrency means: every stacked check runs to completion
+  regardless of whether an earlier one already succeeded (wasted Keycloak/UMA2 round-trips, worse
+  for the more expensive `Subsystem.Manage`/`Connection.Manage` discovery-based checks); the
+  *value* returned to the controller as `request.user` is whichever check happened to settle
+  first in wall-clock time, not a deterministic/prioritized choice; and on total failure, the
+  403 message shown is whichever check happened to reject *last* (`failedAttempts.pop()` in the
+  generated code), not necessarily the most relevant one. This was the previous shape of every
+  OR'd endpoint in this doc and is why the response-filtering code in
+  `listOrganizationServices`/`listConnections` had to re-derive the caller's scopes from the raw
+  JWT claim instead of trusting the resolved `request.user`/`request.oauth_user.scope` — see
+  "Listing connections and oas-services with gateway-scoped permissions" below.
+- **A single decorator with a multi-scope array** results in exactly **one** call to
+  `expressAuthentication` per request (`Object.keys(secMethod).length === 1` in the generated
+  code takes the non-racing branch). `expressAuthentication` (`src/auth/auth-tsoa.ts`) now
+  implements the OR itself, sequentially: `authorizeAnyScope` tries each scope in array order via
+  `authorizeScope`, returning on the first success and only falling through to the next scope on
+  failure; if every scope fails, it throws one `ForbiddenError` listing every scope that was
+  tried and why. Declaring `System.Manage` first means the common case (an org-wide admin) never
+  pays for `Subsystem.Manage`'s extra gateway-resolution/UMA2-discovery work, and the winning
+  scope — and therefore `request.user`/`request.permissions` — is now deterministic rather than a
+  function of network timing.
+
+All multi-scope endpoints in this document were migrated to the single-decorator form as part of
+this fix; `expressAuthentication`'s scope-resolution logic (`resolveGatewayIdForScope`,
+`resolveGenericResource`, `enforcePermission`) was factored out to be reusable per-scope rather
+than assuming a single resource shared across an entire call's scopes list. This is shared,
+non-generated code used by every `sdx/v1` (and `v1`/`v2`/`v3`) controller, so the fix applies
+everywhere `expressAuthentication` is used, not just the endpoints that currently declare
+multiple scopes.
+
 ### Listing connections and oas-services with gateway-scoped permissions
 
 `GET /organizations/{org}/oas-services` (`listOrganizationServices`) and
@@ -201,13 +243,13 @@ both endpoints use the same two-step, discovery-based design across `src/auth/au
    `oas-services`; no `body.serviceId` for `connections`), `AuthMiddle.getPermittedNamespacesForScope`
    performs a UMA2 permission-ticket exchange (`requestTicket` + `getPermittedResourcesUsingTicket`,
    evaluated against the caller's own bearer token) asking Keycloak "which gateway namespaces
-   does this caller hold [that scope] on, if any." A non-empty result passes that security
-   branch (OR'd with the `System.Manage` branch); an empty result rejects with 403.
+   does this caller hold [that scope] on, if any." A non-empty result passes that scope's check
+   (tried after `System.Manage`, per "Deterministic scope OR" below — `System.Manage` alone
+   already grants access without ever reaching this discovery call); an empty result on the last
+   scope tried rejects with 403.
 2. **Response filtering** (`OrgServiceController.listOrganizationServices` /
    `OrgConnectionController.listConnections`): each controller independently re-derives the
-   same thing — first checking the caller's raw JWT `scope` claim (`request.oauth_user.scope`,
-   not the racy resolved `request.user.scope`, since two stacked `@Security` checks run
-   concurrently and a caller holding both scopes could have either one "win") for
+   same thing — checking the caller's raw JWT `scope` claim (`request.oauth_user.scope`) for
    `System.Manage`. If present, it returns the full unfiltered list (existing behavior,
    unchanged). If absent, it calls the same discovery flow itself (`getPermittedNamespaceNames`,
    exported from `src/services/workflow/get-namespaces.ts`) to get the caller's permitted
@@ -221,13 +263,22 @@ both endpoints use the same two-step, discovery-based design across `src/auth/au
      the provider service's name, not a relationship. Connections are inherently
      provider-gateway-scoped this way; there's no client-side equivalent for `Connection.Manage`.
 
+   Reading the raw `request.oauth_user.scope` claim here (rather than the resolved
+   `request.user.scope` the auth middleware settled on) is no longer needed to dodge a race —
+   see "Deterministic scope OR" below, the auth middleware itself is now race-free — but it's
+   kept because it answers a genuinely different question: "does this caller hold `System.Manage`
+   *at all*," not "which scope happened to authorize this particular request." A caller holding
+   both scopes is now deterministically authorized via `System.Manage` (tried first), so in
+   practice `request.user.scope` would give the same answer today, but the explicit claim check
+   doesn't depend on that ordering staying stable.
+
 This means two Keycloak round-trips for a scope-only list call (one to authorize, one to
-filter) rather than one — deliberately not shared across the request, since the authorization
-check and the response-filtering check run in a race with the `System.Manage` branch and aren't
-guaranteed to both complete before the controller runs. `getMyNamespaces` in the same file
-already did the identical two-step UMA2 flow (ticket → resource ids → resource details) for the
-namespaces report; `getPermittedResourceIds` was extracted out of it so both that and the new
-`getPermittedNamespaceNames` share the ticket-exchange logic.
+filter) rather than one — not shared across the request, since the authorization check happens
+in the auth middleware (`auth-tsoa.ts`, before the controller method even runs) and the
+response-filtering check happens independently inside the controller. `getMyNamespaces` in the
+same file already did the identical two-step UMA2 flow (ticket → resource ids → resource
+details) for the namespaces report; `getPermittedResourceIds` was extracted out of it so both
+that and the new `getPermittedNamespaceNames` share the ticket-exchange logic.
 
 ## Inconsistencies & recommendations
 
@@ -261,7 +312,7 @@ namespaces report; `getPermittedResourceIds` was extracted out of it so both tha
    Keystone roles) no longer share an ambiguous name.
 
 3. **Connections CRUD is inconsistently scoped — `[resolved]`.** `listConnections` now also
-   accepts `Connection.Manage` (stacked `@Security`), including a real, working list: approval
+   accepts `Connection.Manage` (multi-scope `@Security`), including a real, working list: approval
    still resolves via `body.serviceId`, and a bare list call now goes through the same
    discovery-based gate + response-filtering used by `Subsystem.Manage`/`listOrganizationServices`
    (see "Listing connections and oas-services with gateway-scoped permissions" above) — a
@@ -282,7 +333,7 @@ namespaces report; `getPermittedResourceIds` was extracted out of it so both tha
 5. **All-or-nothing admin model within an org — `[partially addressed]`.** `Subsystem.Manage`
    (all of `oas-services`, plus connection create/delete) and `Connection.Manage` (connection
    approval + list) now both give gateway-scoped alternatives to `System.Manage` (additive, via
-   stacked `@Security` — existing `system-admin` holders are unaffected), including real,
+   multi-scope `@Security` — existing `system-admin` holders are unaffected), including real,
    filtered listing where a list operation exists — a scope-only holder gets back just their own
    gateways' data via the shared UMA2 discovery pattern (see "Listing connections and
    oas-services with gateway-scoped permissions" above), not the whole org's and not a 403. This

--- a/src/auth/auth-tsoa.ts
+++ b/src/auth/auth-tsoa.ts
@@ -38,162 +38,249 @@ let kcConfig: any = {
 
 let keycloak = new Keycloak({}, kcConfig);
 
+/**
+ * Resolves the specific gateway namespace resource that `scope` should be
+ * checked against for this request, for the scopes that resolve dynamically
+ * per-request. Returns undefined for scopes with no per-request resource
+ * resolution (e.g. `System.Manage`, resolved generically in
+ * `resolveGenericResource` below) or for the list/discovery case (no
+ * identifying resource on the request at all).
+ *
+ * Throws a `ForbiddenError` for the two cases where a resource is required
+ * to even attempt the check but couldn't be resolved (`GatewayPattern.Publish`,
+ * and `Connection.Manage` when a `serviceId` was supplied but doesn't resolve) -
+ * this mirrors the original behavior of rejecting immediately rather than
+ * falling through to a generic/discovery check that could never succeed.
+ */
+async function resolveGatewayIdForScope(
+  request: any,
+  authMiddle: AuthMiddle,
+  scope: string
+): Promise<string | undefined> {
+  if (scope === 'GatewayPattern.Publish') {
+    const gatewayId = await authMiddle.lookupGatewayId(
+      request.params.org,
+      request.params.pattern,
+      request.body
+    );
+    if (!gatewayId) {
+      throw new ForbiddenError('permission_denied', {
+        message: `Unable to find gateway detail from pattern '${request.params.pattern}'`,
+      });
+    }
+    return gatewayId;
+  }
+
+  if (scope === 'Connection.Manage') {
+    // Approval (and any other serviceId-bearing call) resolves to that
+    // service's gateway. Listing has no serviceId to resolve from and is
+    // handled by the discovery-based check instead.
+    if (!request.body?.serviceId) {
+      return undefined;
+    }
+    const gatewayId = await authMiddle.lookupGatewayId(
+      request.params.org,
+      request.params.pattern,
+      request.body
+    );
+    if (!gatewayId) {
+      throw new ForbiddenError('permission_denied', {
+        message: `Unable to find gateway detail for service '${request.body.serviceId}'`,
+      });
+    }
+    return gatewayId;
+  }
+
+  if (scope === 'Subsystem.Manage') {
+    // oas-services get/spec/delete resolve to that service's own gateway (`name`);
+    // oas-services create resolves to the target subsystem's gateway (`subsystem`);
+    // connection create resolves via `body.serviceId`; connection delete resolves
+    // via `id`, looked up to that connection's own serviceId. List (either
+    // endpoint) has no identifying resource and is handled by the
+    // discovery-based check instead.
+    return authMiddle.lookupSubsystemManageGatewayId(
+      request.params.org,
+      request.params.name,
+      request.query?.subsystem,
+      request.body?.serviceId,
+      request.params.id
+    );
+  }
+
+  return undefined;
+}
+
+function resolveGenericResource(request: any): string {
+  if ('orgUnit' in request.params) {
+    return `org/${request.params.orgUnit}`;
+  } else if ('org' in request.params) {
+    return `org/${request.params.org}`;
+  } else if ('gatewayId' in request.params) {
+    return request.params.gatewayId;
+  } else if ('gatewayId' in request.query) {
+    return request.query.gatewayId;
+  }
+  // assume it is namespace-based protection
+  return request.params.ns;
+}
+
+/** Runs the keycloak UMA2 enforcer for a single `resource:scope` permission. */
+function enforcePermission(
+  request: any,
+  securityName: string,
+  permission: string,
+  scope: string
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    logger.debug("[%s] Resource Authorization on '%j'", securityName, [
+      permission,
+    ]);
+
+    // keycloak enforcer() needs the subject_token to be the "Authorization: Bearer"
+    // so ensure that this is set; is applicable when the user has authenticated via the Portal
+    request.headers.authorization = `Bearer ${GetRequestAuthToken(request)}`;
+
+    keycloak.enforcer([permission])(
+      request,
+      {
+        status: (s: number) => {
+          logger.error(
+            'permission_denied (%d) [%j] for %j',
+            s,
+            [permission],
+            request.oauth_user
+          );
+          reject(
+            new ForbiddenError('permission_denied', {
+              message: `Missing required scope: ${permission}`,
+            })
+          );
+        },
+        end: (text: string) => false,
+      } as any,
+      (authzerr: any) => {
+        if (authzerr) {
+          reject(
+            new ForbiddenError('permission_denied', {
+              message: 'Denied access to resource',
+            })
+          );
+        } else {
+          logger.debug('Returned Permissions %j', request.permissions);
+          resolve({ ...request.oauth_user, scope });
+        }
+      }
+    );
+  });
+}
+
+/**
+ * Attempts authorization for a single scope, returning the resolved user on
+ * success or throwing a `ForbiddenError` on failure. Used both for a single
+ * required scope and, via `authorizeAnyScope` below, as one alternative of
+ * several tried in order for a stacked/OR'd `@Security` requirement.
+ */
+async function authorizeScope(
+  request: any,
+  authMiddle: AuthMiddle,
+  securityName: string,
+  scope: string
+): Promise<any> {
+  const sdxGatewayId = await resolveGatewayIdForScope(
+    request,
+    authMiddle,
+    scope
+  );
+
+  const isDiscoveryScope =
+    scope === 'Subsystem.Manage' || scope === 'Connection.Manage';
+  if (isDiscoveryScope && !sdxGatewayId) {
+    // List has no single resource to check against - "authorized" here
+    // means "holds this scope on at least one gateway." The controller
+    // independently re-discovers and filters by that same set to decide
+    // what to actually return.
+    const namespaces = await authMiddle.getPermittedNamespacesForScope(
+      request,
+      [scope]
+    );
+    if (namespaces.length === 0) {
+      throw new ForbiddenError('permission_denied', {
+        message: `Missing required scope: ${scope}`,
+      });
+    }
+    return { ...request.oauth_user, scope };
+  }
+
+  const resource = sdxGatewayId || resolveGenericResource(request);
+
+  return enforcePermission(
+    request,
+    securityName,
+    `${resource}:${scope}`,
+    scope
+  );
+}
+
+/**
+ * Tries each scope in `scopes`, in order, stopping at the first one that
+ * succeeds - a single, deterministic, sequential OR rather than tsoa's
+ * default behavior of racing every stacked `@Security` decorator
+ * concurrently via `Promise.any` (see routes.ts's generated
+ * `authenticateMiddleware`). Sequential trial also means a request that's
+ * authorized by an earlier, cheaper scope (e.g. org-wide `System.Manage`)
+ * never pays for a later, more expensive one's lookups (e.g. `Subsystem.Manage`'s
+ * gateway resolution + UMA2 discovery call).
+ *
+ * Throws a single `ForbiddenError` listing every scope that was tried if
+ * none succeed, rather than an arbitrary "whichever attempt happened to
+ * fail last" message.
+ */
+async function authorizeAnyScope(
+  request: any,
+  authMiddle: AuthMiddle,
+  securityName: string,
+  scopes: string[]
+): Promise<any> {
+  const failures: string[] = [];
+  for (const scope of scopes) {
+    try {
+      return await authorizeScope(request, authMiddle, securityName, scope);
+    } catch (err: any) {
+      failures.push(`${scope} (${err?.message || err})`);
+    }
+  }
+
+  throw new ForbiddenError('permission_denied', {
+    message: `Missing required scope. Tried: ${failures.join('; ')}`,
+  });
+}
+
 export function expressAuthentication(
   request: any,
   securityName: string,
-  scopes?: string[]
+  scopes: string[] = []
 ): Promise<any> {
   const authMiddle = container.resolve(AuthMiddle);
 
-  return new Promise(async (resolve: any, reject: any) => {
-    let sdxGatewayId: string;
-
-    if (scopes?.find((s) => s === 'GatewayPattern.Publish')) {
-      const gatewayId = await authMiddle.lookupGatewayId(
-        request.params.org,
-        request.params.pattern,
-        request.body
-      );
-      if (gatewayId) {
-        sdxGatewayId = gatewayId;
-      } else {
-        return reject(
-          new ForbiddenError('permission_denied', {
-            message: `Unable to find gateway detail from pattern '${request.params.pattern}'`,
-          })
-        );
-      }
-    } else if (scopes?.find((s) => s === 'Connection.Manage')) {
-      // Approval (and any other serviceId-bearing call) resolves to that
-      // service's gateway. Listing has no serviceId to resolve from and is
-      // handled below via a discovery-based check instead.
-      if (request.body?.serviceId) {
-        const gatewayId = await authMiddle.lookupGatewayId(
-          request.params.org,
-          request.params.pattern,
-          request.body
-        );
-        if (gatewayId) {
-          sdxGatewayId = gatewayId;
-        } else {
-          return reject(
-            new ForbiddenError('permission_denied', {
-              message: `Unable to find gateway detail for service '${request.body.serviceId}'`,
-            })
-          );
-        }
-      }
-    } else if (scopes?.find((s) => s === 'Subsystem.Manage')) {
-      // oas-services get/spec/delete resolve to that service's own gateway (`name`);
-      // oas-services create resolves to the target subsystem's gateway (`subsystem`);
-      // connection create resolves via `body.serviceId`; connection delete resolves
-      // via `id`, looked up to that connection's own serviceId. List (either
-      // endpoint) has no identifying resource and is handled below via a
-      // discovery-based check instead.
-      sdxGatewayId = await authMiddle.lookupSubsystemManageGatewayId(
-        request.params.org,
-        request.params.name,
-        request.query?.subsystem,
-        request.body?.serviceId,
-        request.params.id
-      );
-    }
-
+  return new Promise((resolve: any, reject: any) => {
     verifyJWT(request, null, async (err: any) => {
       if (err) {
         logger.debug('ERROR Verifying JWT ' + err);
         return reject(err);
-      } else {
-        logger.debug('RESOLVED %j', request.oauth_user);
+      }
 
-        if (scopes.length == 0) {
-          return resolve(request.oauth_user);
-        }
+      logger.debug('RESOLVED %j', request.oauth_user);
 
-        const discoveryScope = scopes.find(
-          (s) => s === 'Subsystem.Manage' || s === 'Connection.Manage'
+      if (scopes.length === 0) {
+        return resolve(request.oauth_user);
+      }
+
+      try {
+        resolve(
+          await authorizeAnyScope(request, authMiddle, securityName, scopes)
         );
-        if (discoveryScope && !sdxGatewayId) {
-          // List has no single resource to check against - "authorized" here
-          // means "holds this scope on at least one gateway." The controller
-          // independently re-discovers and filters by that same set to
-          // decide what to actually return.
-          const namespaces = await authMiddle.getPermittedNamespacesForScope(
-            request,
-            [discoveryScope]
-          );
-          if (namespaces.length === 0) {
-            return reject(
-              new ForbiddenError('permission_denied', {
-                message: `Missing required scope: ${discoveryScope}`,
-              })
-            );
-          }
-          return resolve({ ...request.oauth_user, scope: discoveryScope });
-        }
-
-        let resource: string;
-        if (sdxGatewayId) {
-          resource = sdxGatewayId;
-        } else if ('orgUnit' in request.params) {
-          resource = `org/${request.params.orgUnit}`;
-        } else if ('org' in request.params) {
-          resource = `org/${request.params.org}`;
-        } else if ('gatewayId' in request.params) {
-          resource = request.params.gatewayId;
-        } else if ('gatewayId' in request.query) {
-          resource = request.query.gatewayId;
-        } else {
-          // assume it is namespace-based protection
-          resource = request.params.ns;
-        }
-
-        const permissions: string[] = scopes.map((s) => `${resource}:${s}`);
-
-        logger.debug(
-          "[%s] Resource Authorization on '%j'",
-          securityName,
-          permissions
-        );
-
-        // keycloak enforcer() needs the subject_token to be the "Authorization: Bearer"
-        // so ensure that this is set; is applicable when the user has authenticated via the Portal
-        request.headers.authorization = `Bearer ${GetRequestAuthToken(
-          request
-        )}`;
-
-        keycloak.enforcer(permissions)(
-          request,
-          {
-            status: (s: number) => {
-              logger.error(
-                'permission_denied (%d) [%j] for %j',
-                s,
-                permissions,
-                request.oauth_user
-              );
-              reject(
-                new ForbiddenError('permission_denied', {
-                  message: `Missing required scope: ${permissions.join(', ')}`,
-                })
-              );
-            },
-            end: (text: string) => false,
-          } as any,
-          (authzerr: any) => {
-            if (authzerr) {
-              reject(
-                new ForbiddenError('permission_denied', {
-                  message: 'Denied access to resource',
-                })
-              );
-            } else {
-              logger.debug('Returned Permissions %j', request.permissions);
-
-              resolve({ ...request.oauth_user, ...{ scope: scopes[0] } });
-            }
-          }
-        );
+      } catch (authzErr) {
+        reject(authzErr);
       }
     });
   });

--- a/src/controllers/sdx/v1/OrgConnectionController.ts
+++ b/src/controllers/sdx/v1/OrgConnectionController.ts
@@ -55,8 +55,7 @@ export class OrgConnectionController extends Controller {
    */
   @Put()
   @OperationId('upsertConnection')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async upsertConnection(
     @Path() org: string,
     @Body() input: ConnectionRequestInput,
@@ -116,8 +115,7 @@ export class OrgConnectionController extends Controller {
    */
   @Get()
   @OperationId('listConnections')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Connection.Manage'])
+  @Security('jwt', ['System.Manage', 'Connection.Manage'])
   public async listConnections(
     @Path() org: string,
     @Request() request: any
@@ -174,8 +172,7 @@ export class OrgConnectionController extends Controller {
    */
   @Delete('/{id}')
   @OperationId('deleteConnection')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async deleteConnection(
     @Path() org: string,
     @Path('id') id: string,

--- a/src/controllers/sdx/v1/OrgServiceController.ts
+++ b/src/controllers/sdx/v1/OrgServiceController.ts
@@ -68,8 +68,7 @@ export class GatewayServiceController extends Controller {
    */
   @Put()
   @OperationId('createOASService')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async createOASService(
     @Path() org: string,
     @Query() subsystem: string,
@@ -140,8 +139,7 @@ export class GatewayServiceController extends Controller {
    */
   @Get()
   @OperationId('listOrganizationOASServices')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async listOrganizationServices(
     @Path() org: string,
     @Request() request: any
@@ -189,8 +187,7 @@ export class GatewayServiceController extends Controller {
    */
   @Get('/{name}')
   @OperationId('getOrganizationOASService')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async getOrganizationOASService(
     @Path() org: string,
     @Path('name') name: string,
@@ -223,8 +220,7 @@ export class GatewayServiceController extends Controller {
    */
   @Get('/{name}/oas-spec')
   @OperationId('getOrganizationServiceSpec')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async getOrganizationServiceSpec(
     @Path() org: string,
     @Path('name') name: string,
@@ -261,8 +257,7 @@ export class GatewayServiceController extends Controller {
    */
   @Delete('/{name}')
   @OperationId('deleteOrganizationOASService')
-  @Security('jwt', ['System.Manage'])
-  @Security('jwt', ['Subsystem.Manage'])
+  @Security('jwt', ['System.Manage', 'Subsystem.Manage'])
   public async delete(
     @Path() org: string,
     @Path('name') name: string,

--- a/src/test/auth/auth-tsoa.test.js
+++ b/src/test/auth/auth-tsoa.test.js
@@ -1,0 +1,194 @@
+require('reflect-metadata');
+
+// express-jwt's JWT verification is stubbed so tests control whether the
+// caller's token "verifies" without doing any real crypto/network work.
+let mockVerifyJWTImpl;
+jest.mock('express-jwt', () => {
+  const mockJwt = jest.fn(() => (request, _response, callback) => {
+    mockVerifyJWTImpl(request, callback);
+  });
+  return Object.assign(mockJwt, {
+    UnauthorizedError: class UnauthorizedError extends Error {},
+  });
+});
+
+jest.mock('jwks-rsa', () => ({
+  expressJwtSecret: jest.fn(() => 'secret-callback'),
+}));
+
+// keycloak-connect's enforcer is stubbed so tests control, per permission
+// string, whether that single scope check passes or fails - this is the
+// piece that used to run N-at-a-time (racing) for stacked @Security
+// decorators and now runs one at a time, in order, via authorizeAnyScope.
+let mockEnforcerImpl;
+const mockEnforcer = jest.fn((permissions) => (request, response, next) => {
+  mockEnforcerImpl(permissions, request, response, next);
+});
+jest.mock('keycloak-connect', () =>
+  jest.fn().mockImplementation(() => ({ enforcer: mockEnforcer }))
+);
+
+const mockAuthMiddle = {
+  lookupGatewayId: jest.fn(),
+  lookupSubsystemManageGatewayId: jest.fn(),
+  getPermittedNamespacesForScope: jest.fn(),
+};
+jest.mock('tsyringe', () => ({
+  container: { resolve: jest.fn(() => mockAuthMiddle) },
+  inject: () => () => {},
+  injectable: () => () => {},
+}));
+
+// auth-sdx-middle.ts and keystoneInjector.ts both use tsyringe's
+// @injectable()/@inject() decorators, which this jest/babel setup isn't
+// configured to parse. auth-tsoa.ts only needs AuthMiddle/KeystoneService
+// as identifiers (container.resolve(AuthMiddle) and a type reference,
+// respectively), never their real implementations, so stub both modules
+// out entirely rather than let babel try to parse the real decorated
+// classes.
+jest.mock('../../auth/auth-sdx-middle', () => ({ AuthMiddle: class {} }));
+jest.mock('../../controllers/ioc/keystoneInjector', () => ({
+  KeystoneService: class {},
+}));
+
+const { expressAuthentication } = require('../../auth/auth-tsoa');
+
+function makeRequest(overrides = {}) {
+  return {
+    params: { org: 'test-org' },
+    query: {},
+    body: {},
+    headers: { authorization: 'Bearer faketoken' },
+    ...overrides,
+  };
+}
+
+describe('expressAuthentication - multi-scope OR', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockVerifyJWTImpl = (request, callback) => {
+      request.oauth_user = { sub: 'user-1', scope: 'System.Manage Subsystem.Manage' };
+      callback();
+    };
+    // Org-scoped System.Manage never needs a gateway lookup.
+    mockAuthMiddle.lookupSubsystemManageGatewayId.mockResolvedValue(undefined);
+  });
+
+  it('tries scopes in declared order and short-circuits on the first success', async () => {
+    mockEnforcerImpl = (permissions, request, response, next) => {
+      if (permissions[0] === 'org/test-org:System.Manage') {
+        return next();
+      }
+      throw new Error(`unexpected permission check: ${permissions[0]}`);
+    };
+
+    const request = makeRequest();
+    const user = await expressAuthentication(request, 'jwt', [
+      'System.Manage',
+      'Subsystem.Manage',
+    ]);
+
+    expect(user.scope).toBe('System.Manage');
+    expect(mockEnforcer).toHaveBeenCalledTimes(1);
+    // The cheaper System.Manage check won, so Subsystem.Manage's gateway
+    // resolution should never have run - proving no wasted work, unlike
+    // the old concurrent/racing behavior where every branch always ran.
+    expect(
+      mockAuthMiddle.lookupSubsystemManageGatewayId
+    ).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the next scope when the first one fails', async () => {
+    mockAuthMiddle.lookupSubsystemManageGatewayId.mockResolvedValue(
+      'gw-namespace-1'
+    );
+    mockEnforcerImpl = (permissions, request, response, next) => {
+      if (permissions[0] === 'org/test-org:System.Manage') {
+        return response.status(403);
+      }
+      if (permissions[0] === 'gw-namespace-1:Subsystem.Manage') {
+        return next();
+      }
+      throw new Error(`unexpected permission check: ${permissions[0]}`);
+    };
+
+    const request = makeRequest({ params: { org: 'test-org', name: 'svc-1' } });
+    const user = await expressAuthentication(request, 'jwt', [
+      'System.Manage',
+      'Subsystem.Manage',
+    ]);
+
+    expect(user.scope).toBe('Subsystem.Manage');
+    expect(mockEnforcer).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects with a single ForbiddenError describing every scope tried when all fail', async () => {
+    mockAuthMiddle.lookupSubsystemManageGatewayId.mockResolvedValue(
+      'gw-namespace-1'
+    );
+    mockEnforcerImpl = (permissions, request, response) => {
+      response.status(403);
+    };
+
+    const request = makeRequest({ params: { org: 'test-org', name: 'svc-1' } });
+
+    await expect(
+      expressAuthentication(request, 'jwt', ['System.Manage', 'Subsystem.Manage'])
+    ).rejects.toMatchObject({
+      status: 403,
+      message: expect.stringContaining('System.Manage'),
+    });
+
+    await expect(
+      expressAuthentication(request, 'jwt', ['System.Manage', 'Subsystem.Manage'])
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Subsystem.Manage'),
+    });
+  });
+
+  it('behaves the same as a plain single-scope check when only one scope is declared', async () => {
+    mockEnforcerImpl = (permissions, request, response, next) => next();
+
+    const request = makeRequest();
+    const user = await expressAuthentication(request, 'jwt', ['System.Manage']);
+
+    expect(user.scope).toBe('System.Manage');
+    expect(mockEnforcer).toHaveBeenCalledTimes(1);
+    expect(mockEnforcer).toHaveBeenCalledWith(['org/test-org:System.Manage']);
+  });
+
+  it('rejects immediately on an invalid JWT without attempting any scope checks', async () => {
+    mockVerifyJWTImpl = (request, callback) => callback(new Error('bad token'));
+
+    const request = makeRequest();
+
+    await expect(
+      expressAuthentication(request, 'jwt', ['System.Manage', 'Subsystem.Manage'])
+    ).rejects.toThrow('bad token');
+    expect(mockEnforcer).not.toHaveBeenCalled();
+  });
+
+  it('resolves via UMA2 discovery for the list case when Subsystem.Manage has no single resource', async () => {
+    mockAuthMiddle.lookupSubsystemManageGatewayId.mockResolvedValue(undefined);
+    mockAuthMiddle.getPermittedNamespacesForScope.mockResolvedValue([
+      'gw-namespace-1',
+    ]);
+    mockEnforcerImpl = (permissions, request, response) => {
+      // System.Manage is tried first and fails, falling through to
+      // Subsystem.Manage's discovery-based check.
+      response.status(403);
+    };
+
+    const request = makeRequest();
+    const user = await expressAuthentication(request, 'jwt', [
+      'System.Manage',
+      'Subsystem.Manage',
+    ]);
+
+    expect(user.scope).toBe('Subsystem.Manage');
+    expect(mockAuthMiddle.getPermittedNamespacesForScope).toHaveBeenCalledWith(
+      request,
+      ['Subsystem.Manage']
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The SP136 work on `hotfix/aps-4799-m0-carryover` (not yet in `dev`) introduced the first `sdx/v1` endpoints that accept more than one alternative permission scope (e.g. `System.Manage` **or** `Subsystem.Manage`), declared as stacked `@Security(...)` decorators. tsoa's generated `authenticateMiddleware` (`src/controllers/sdx/v1/routes.ts`) races stacked decorators concurrently via a `promise.any`-based OR — correct for the pass/fail decision, but every branch still runs to completion even after another already succeeded (extra Keycloak/UMA2 round-trips on every OR'd request), the `request.user` value is whichever check happens to settle first rather than a deterministic/prioritized choice, and the 403 shown on total failure is whichever check happened to reject *last* — not necessarily the most relevant one.
- Collapses every stacked `@Security` pair in `sdx/v1` into a single `@Security('jwt', [scopeA, scopeB])` decorator, and reworks `expressAuthentication` (`src/auth/auth-tsoa.ts`) to resolve a multi-scope array itself: `authorizeAnyScope` tries each scope **in order**, short-circuiting on the first success, and throws one `ForbiddenError` listing every scope tried if all fail. Resource resolution and permission enforcement were factored into small per-scope helpers (`resolveGatewayIdForScope`, `resolveGenericResource`, `enforcePermission`) so this applies uniformly to every `@Security` usage across `v1`/`v2`/`v3`/`sdx/v1`, not just the newly multi-scope endpoints (single-scope calls behave identically to before).
- Restores `System.Manage` as an alternative to `Subsystem.Manage` on `oas-services` create/delete (`OrgServiceController`), for consistency with every other multi-scope endpoint now that the OR mechanism is deterministic.
- Regenerated `src/controllers/sdx/v1/routes.ts`/`openapi.yaml` (build artifacts, gitignored, not part of this diff) to confirm the new security declarations produce the intended single, non-racing `authenticateMiddleware` call per endpoint.
- Updated `docs/sdx-v1-permissions-audit.md` with a new "Deterministic scope OR" section describing the previous race and the fix, and removed the now-stale "racy `request.user.scope`" caveats.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Full `jest` suite (`src/test`) — 16 suites / 101 tests passing, including new `src/test/auth/auth-tsoa.test.js` covering: deterministic ordering + short-circuit (no wasted work on the losing scope), fallback to the next scope on failure, combined error message listing every scope tried, single-scope backward compatibility, fail-fast on an invalid JWT, and UMA2-discovery fallback for the list case
- [ ] e2e (`ds/api/sdx/v1` Cypress suites) — not run here; the existing suite only exercises a single fixed test identity (`System.Manage`-holding admin), so it doesn't isolate the OR behavior itself (that's what the new unit tests cover), but it does exercise the happy path for every endpoint touched here and should be run as part of normal CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)