### PR TITLE
Record activity for subsystem RBAC access updates

### DIFF
--- a/src/controllers/sdx/v1/OrgSubsystemController.ts
+++ b/src/controllers/sdx/v1/OrgSubsystemController.ts
@@ -35,6 +35,13 @@ import { getRoutePathPrefix } from '../../../services/utils';
 import { GroupAccessService } from '../../../services/org-groups';
 import { SysGroupAccessService } from '../../../services/org-groups/sys-group-access';
 import { GroupMember, GroupMembership } from '../../../services/org-groups/types';
+import {
+  buildOrgAccessDisplayNameResolver,
+  logSubsystemAccessChanges,
+} from '../../../services/workflow/org-activity';
+import { Logger } from '../../../logger';
+
+const logger = Logger('controller.org-subsystem');
 
 @injectable()
 @Route('/organizations/{org}/subsystems')
@@ -277,7 +284,7 @@ export class OrgSubsystemController extends Controller {
       envConfig.clientSecret
     );
 
-    await sysGroupAccessService.createOrUpdateGroupAccess(
+    const changes = await sysGroupAccessService.createOrUpdateGroupAccess(
       'subsystem',
       {
         name: client.clientId,
@@ -285,6 +292,22 @@ export class OrgSubsystemController extends Controller {
         members: body.members,
       },
       ['idir']
+    );
+
+    const resolveDisplayName = await buildOrgAccessDisplayNameResolver(
+      envConfig.issuerUrl,
+      envConfig.clientId,
+      envConfig.clientSecret
+    );
+
+    await logSubsystemAccessChanges(
+      context,
+      org,
+      name,
+      changes,
+      resolveDisplayName
+    ).catch((e) =>
+      logger.error('[OrgActivity] subsystem access changes %s', e)
     );
   }
 }

--- a/src/services/workflow/org-activity.ts
+++ b/src/services/workflow/org-activity.ts
@@ -853,6 +853,41 @@ export class OrgActivityService {
     });
   }
 
+  async logUpdateSubsystemAccess(
+    success: boolean,
+    data: {
+      subsystemName: string;
+      subject_email: string;
+      subject: string;
+      roles: string;
+    }
+  ): Promise<void> {
+    const resource = {
+      kind: OrgActivityResourceKind.Subsystem,
+      value: data.subsystemName,
+    };
+    return this.recordOrgActivity({
+      success,
+      message:
+        '{actor} {action} {subject} subsystem access on {subsystemName} in {organization}: {roles}',
+      params: {
+        action: 'updated',
+        entity: 'SubsystemAccess',
+        actor: this.getActorName(),
+        organization: this.orgName,
+        subsystemName: data.subsystemName,
+        subject_email: data.subject_email,
+        subject: data.subject,
+        roles: data.roles,
+      },
+      resource,
+      filterResources: [
+        resource,
+        { kind: OrgActivityResourceKind.User, value: data.subject_email },
+      ],
+    });
+  }
+
   async logServicePublished(
     success: boolean,
     data: { serviceName: string; subsystemName: string }
@@ -1149,6 +1184,40 @@ export async function logOrganizationAccessChanges(
       ),
       resource,
       orgUnit,
+    });
+  }
+}
+
+/**
+ * Records one activity entry per member whose subsystem RBAC role
+ * membership changed (subsystem-owner/tech-lead/access-manager) — the
+ * subsystem-scoped counterpart to logOrganizationAccessChanges above.
+ */
+export async function logSubsystemAccessChanges(
+  context: any,
+  orgName: string,
+  subsystemName: string,
+  changes: {
+    granted: Record<string, string[]>;
+    revoked: Record<string, string[]>;
+  },
+  resolveDisplayName: (email: string) => Promise<string>
+): Promise<void> {
+  const orgActivity = new OrgActivityService(context, orgName);
+  const emails = new Set([
+    ...Object.keys(changes.granted || {}),
+    ...Object.keys(changes.revoked || {}),
+  ]);
+
+  for (const email of emails) {
+    await orgActivity.logUpdateSubsystemAccess(true, {
+      subsystemName,
+      subject_email: email,
+      subject: await resolveDisplayName(email),
+      roles: signRoleDelta(
+        changes.granted[email] ?? [],
+        changes.revoked[email] ?? []
+      ),
     });
   }
 }

--- a/src/test/services/workflow/org-activity-subsystem-access.test.js
+++ b/src/test/services/workflow/org-activity-subsystem-access.test.js
@@ -1,0 +1,159 @@
+import {
+  OrgActivityService,
+  logSubsystemAccessChanges,
+} from '../../../services/workflow/org-activity';
+import * as activityModule from '../../../services/keystone/activity';
+
+jest.mock('../../../services/keystone/activity', () => {
+  const actual = jest.requireActual('../../../services/keystone/activity');
+  return {
+    ...actual,
+    recordActivity: jest.fn().mockResolvedValue({}),
+    recordActivityWithBlob: jest.fn().mockResolvedValue({}),
+  };
+});
+
+const recordActivityMock = activityModule.recordActivity;
+
+function getRecordActivityCall(mock, callIndex = 0) {
+  const [
+    context,
+    action,
+    type,
+    refId,
+    message,
+    result,
+    activityContext,
+    productNamespace,
+    ids,
+  ] = mock.mock.calls[callIndex];
+  return {
+    context,
+    action,
+    type,
+    refId,
+    message,
+    result,
+    activityContext,
+    productNamespace,
+    ids,
+  };
+}
+
+describe('OrgActivityService.logUpdateSubsystemAccess', function () {
+  beforeEach(() => {
+    recordActivityMock.mockClear();
+  });
+
+  it('records "updated" with the signed delta, scoped to the subsystem', async function () {
+    const service = new OrgActivityService(
+      { authedItem: { name: 'Admin' } },
+      'my-org'
+    );
+
+    await service.logUpdateSubsystemAccess(true, {
+      subsystemName: 'my-subsystem',
+      subject_email: 'user1@local',
+      subject: 'User One',
+      roles: '[+] tech-lead',
+    });
+
+    const call = getRecordActivityCall(recordActivityMock);
+    expect(call.action).toBe('updated');
+    expect(call.type).toBe('SubsystemAccess');
+    expect(call.refId).toBe('subsystem:my-subsystem');
+    expect(call.ids).toEqual([
+      'org:my-org',
+      'subsystem:my-subsystem',
+      'user:user1@local',
+      'actor:Admin',
+    ]);
+    expect(call.message).toBe(
+      'Admin updated User One subsystem access on my-subsystem in my-org: [+] tech-lead'
+    );
+    const ctx = JSON.parse(call.activityContext);
+    expect(ctx.message).toBe(
+      '{actor} {action} {subject} subsystem access on {subsystemName} in {organization}: {roles}'
+    );
+  });
+});
+
+describe('logSubsystemAccessChanges', function () {
+  const resolveDisplayName = async (email) =>
+    email === 'aidan@idir' ? 'Cope, Aidan CITZ:EX' : email;
+  const activityContext = { authedItem: { name: 'Admin' } };
+
+  beforeEach(() => {
+    recordActivityMock.mockClear();
+  });
+
+  it('records "updated" with only the added role delta on a pure grant', async function () {
+    await logSubsystemAccessChanges(
+      activityContext,
+      'my-org',
+      'my-subsystem',
+      {
+        granted: { 'aidan@idir': ['tech-lead'] },
+        revoked: {},
+      },
+      resolveDisplayName
+    );
+
+    expect(recordActivityMock).toHaveBeenCalledTimes(1);
+    const call = getRecordActivityCall(recordActivityMock);
+    expect(call.action).toBe('updated');
+    expect(call.refId).toBe('subsystem:my-subsystem');
+    expect(call.message).toBe(
+      'Admin updated Cope, Aidan CITZ:EX subsystem access on my-subsystem in my-org: [+] tech-lead'
+    );
+  });
+
+  it('records a combined grant/revoke delta for the same member', async function () {
+    await logSubsystemAccessChanges(
+      activityContext,
+      'my-org',
+      'my-subsystem',
+      {
+        granted: { 'aidan@idir': ['access-manager'] },
+        revoked: { 'aidan@idir': ['tech-lead'] },
+      },
+      resolveDisplayName
+    );
+
+    const call = getRecordActivityCall(recordActivityMock);
+    expect(call.message).toBe(
+      'Admin updated Cope, Aidan CITZ:EX subsystem access on my-subsystem in my-org: [+] access-manager, [-] tech-lead'
+    );
+  });
+
+  it('records one activity entry per affected member', async function () {
+    await logSubsystemAccessChanges(
+      activityContext,
+      'my-org',
+      'my-subsystem',
+      {
+        granted: { 'aidan@idir': ['tech-lead'], 'mark@idir': ['subsystem-owner'] },
+        revoked: {},
+      },
+      resolveDisplayName
+    );
+
+    expect(recordActivityMock).toHaveBeenCalledTimes(2);
+    const emails = recordActivityMock.mock.calls.map(
+      (call) => JSON.parse(call[6]).params.subject_email
+    );
+    expect(emails.sort()).toEqual(['aidan@idir', 'mark@idir']);
+  });
+
+  it('records nothing when there are no changes', async function () {
+    await logSubsystemAccessChanges(
+      activityContext,
+      'my-org',
+      'my-subsystem',
+      { granted: {}, revoked: {} },
+      resolveDisplayName
+    );
+
+    expect(recordActivityMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `PUT /organizations/{org}/subsystems/{name}/access` (`OrgSubsystemController.putAccess`) updates a subsystem's `subsystem-owner`/`tech-lead`/`access-manager` RBAC membership via `SysGroupAccessService.createOrUpdateGroupAccess`, but never recorded any activity — unlike the equivalent org-level endpoint (`v3/OrganizationController.put` → `logOrganizationAccessChanges`), so subsystem RBAC changes were invisible in the activity log/audit trail.
- Added `logSubsystemAccessChanges` + `OrgActivityService.logUpdateSubsystemAccess` to `src/services/workflow/org-activity.ts`, mirroring the existing `logOrganizationAccessChanges`/`logUpdateOrganizationAccess` pattern but scoped to the `Subsystem` resource instead of the org/org-unit hierarchy. `SysGroupAccessService.createOrUpdateGroupAccess` already returns the same `{granted, revoked}` diff shape the org-level helper consumes, so the same diffing/signed-delta logic (`[+] role`, `[-] role`) is reused as-is.
- Wired it into `putAccess` the same way `v3/OrganizationController.put` does: diff the membership change, resolve display names via `buildOrgAccessDisplayNameResolver`, and record one activity entry per affected member — wrapped so a logging failure can't break the actual mutation response, matching every other activity-recording call site in this codebase.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Full `jest` suite — 17/17 suites, 106/106 tests passing, including new `src/test/services/workflow/org-activity-subsystem-access.test.js` covering: single-member grant, combined grant+revoke delta for one member, one activity entry per affected member on a multi-member change, and no activity recorded when there's no actual change
- [ ] e2e — not run here; no existing e2e coverage asserts on activity recording for this endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)