### PR TITLE
Resolve SDX Operator edge URL per environment instead of a single global env var

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -1,0 +1,18 @@
+name: Review PR
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+
+jobs:
+  review:
+    uses: bcgov/aps-devops/.github/workflows/pr-multi-review.yml@main
+    with:
+      pr_number: ${{ inputs.pr_number }}
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   review:
-    uses: bcgov/aps-devops/.github/workflows/pr-multi-review.yml@main
+    uses: bcgov/aps-devops/.github/workflows/pr-multi-review.yml@pr-multi-review
     with:
       pr_number: ${{ inputs.pr_number }}
     secrets: inherit

--- a/local/provisioner/.env.local
+++ b/local/provisioner/.env.local
@@ -5,8 +5,6 @@ PORT=3030
 LOG_LEVEL=debug
 OAUTH_ALLOW_INSECURE_REQUESTS=true
 
-SDX_OPERATOR_CONSUMER_URL=http://kong-sdx-edge0.localtest.me:9080
-
 SDX_PUBLIC_URL=http://kong-sdx-edge0.localtest.me:9080
 
 APS_BASE_URL=http://oauth2proxy.localtest.me:4180/ds/api/v3

--- a/local/provisioner/.env.local
+++ b/local/provisioner/.env.local
@@ -5,8 +5,6 @@ PORT=3030
 LOG_LEVEL=debug
 OAUTH_ALLOW_INSECURE_REQUESTS=true
 
-SDX_PUBLIC_URL=http://kong-sdx-edge0.localtest.me:9080
-
 APS_BASE_URL=http://oauth2proxy.localtest.me:4180/ds/api/v3
 APS_TOKEN_URL=http://keycloak.localtest.me:9081/auth/realms/master/protocol/openid-connect/token
 APS_CLIENT_ID=sdx-provisioner

--- a/local/provisioner/environments.json
+++ b/local/provisioner/environments.json
@@ -5,7 +5,8 @@
     "gwa_api_url": "http://gwa-api.localtest.me:2000/v2",
     "kong_admin_url": "http://kong-sdx-admin0.localtest.me:9081",
     "operator_edge_url": "http://kong-sdx-edge0.localtest.me:9080",
-    "ca_token_url": "http://step-token-api.localtest.me:2020"
+    "ca_token_url": "http://step-token-api.localtest.me:2020",
+    "public_url": "http://kong-sdx-edge0.localtest.me:9080"
   },
   "cyp": {
     "client_id": "sdx-provisioner",
@@ -13,6 +14,7 @@
     "gwa_api_url": "http://gwa-api.localtest.me:2000/v2",
     "kong_admin_url": "http://kong-sdx-admin0.localtest.me:9081",
     "operator_edge_url": "http://kong-sdx-edge0.localtest.me:9080",
-    "ca_token_url": "http://step-token-api-2.localtest.me:2022"
+    "ca_token_url": "http://step-token-api-2.localtest.me:2022",
+    "public_url": "http://kong-sdx-edge0.localtest.me:9080"
   }
 }

--- a/provisioner-api/.env.example
+++ b/provisioner-api/.env.example
@@ -48,7 +48,12 @@ CSS_CLIENT_SECRET=changeme
 # NODE_ENV=production. Use only against local/non-TLS auth servers.
 # OAUTH_ALLOW_INSECURE_REQUESTS=true
 
-# The SDX Operator edge server (used for CSR generation and the gateway
-# patterns' KMS/JWKS routing) is configured per environment via
-# `operator_edge_url` in the environments config (ENVIRONMENTS_CONFIG_FILE),
-# so the correct edge endpoint is called for each environment (dev/test/prod/…).
+# The SDX Operator edge server (used for CSR generation and route host
+# resolution) is configured per environment via `operator_edge_url` in the
+# environments config (ENVIRONMENTS_CONFIG_FILE), so the correct edge endpoint
+# is called for each environment (dev/test/prod/…).
+#
+# The public-facing base URL used to build the `jwks_uri` gateway plugin
+# config (so peers verifying signed requests/responses can reach it, unlike
+# operator_edge_url which is internal-only) is configured per environment via
+# `public_url` in the same file.

--- a/provisioner-api/.env.example
+++ b/provisioner-api/.env.example
@@ -48,8 +48,7 @@ CSS_CLIENT_SECRET=changeme
 # NODE_ENV=production. Use only against local/non-TLS auth servers.
 # OAUTH_ALLOW_INSECURE_REQUESTS=true
 
-SDX_OPERATOR_CONSUMER_URL=http://kong-sdx-edge0.localtest.me:9080
-# The SDX Operator edge server used for CSR generation is configured per
-# environment via `operator_edge_url` in the environments config
-# (ENVIRONMENTS_CONFIG_FILE), so the correct edge endpoint is called for each
-# environment (dev/test/prod/…).
+# The SDX Operator edge server (used for CSR generation and the gateway
+# patterns' KMS/JWKS routing) is configured per environment via
+# `operator_edge_url` in the environments config (ENVIRONMENTS_CONFIG_FILE),
+# so the correct edge endpoint is called for each environment (dev/test/prod/…).

--- a/provisioner-api/.env.local
+++ b/provisioner-api/.env.local
@@ -7,8 +7,6 @@ PORT=3030
 LOG_LEVEL=debug
 OAUTH_ALLOW_INSECURE_REQUESTS=true
 
-SDX_PUBLIC_URL=http://kong-sdx-edge0.localtest.me:9080
-
 # --- APS (signed JWT / private_key_jwt, key in JKS keystore) ---
 APS_BASE_URL=http://oauth2proxy.localtest.me:4180/ds/api/v3
 APS_TOKEN_URL=http://keycloak.localtest.me:9081/auth/realms/master/protocol/openid-connect/token

--- a/provisioner-api/.env.local
+++ b/provisioner-api/.env.local
@@ -7,8 +7,6 @@ PORT=3030
 LOG_LEVEL=debug
 OAUTH_ALLOW_INSECURE_REQUESTS=true
 
-SDX_OPERATOR_CONSUMER_URL=http://kong-sdx-edge0.localtest.me:9080
-
 SDX_PUBLIC_URL=http://kong-sdx-edge0.localtest.me:9080
 
 # --- APS (signed JWT / private_key_jwt, key in JKS keystore) ---

--- a/provisioner-api/src/config/environments.test.ts
+++ b/provisioner-api/src/config/environments.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for environments.ts
+ * Run with: npx tsx src/config/environments.test.ts
+ */
+
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getRequiredEnvUrl, resetEnvironmentsCache } from './environments.js';
+
+// ---------------------------------------------------------------------------
+// Tiny test runner
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function expect(actual: unknown) {
+  return {
+    toBe(expected: unknown, label: string) {
+      if (actual === expected) {
+        console.log(`  ✓  ${label}`);
+        passed++;
+      } else {
+        console.error(`  ✗  ${label}`);
+        console.error(`       expected: ${JSON.stringify(expected)}`);
+        console.error(`       received: ${JSON.stringify(actual)}`);
+        failed++;
+      }
+    },
+  };
+}
+
+function describe(name: string, fn: () => void) {
+  console.log(`\n▸ ${name}`);
+  fn();
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: a temp environments config file
+// ---------------------------------------------------------------------------
+
+const configPath = join(tmpdir(), `environments.test.${process.pid}.json`);
+writeFileSync(
+  configPath,
+  JSON.stringify({
+    dev: {
+      oauth_token_url: 'https://oidc.example.gov.bc.ca/token',
+      kong_admin_url: 'http://kong:8001',
+      operator_edge_url: 'https://edge.dev.example.gov.bc.ca',
+    },
+    test: {
+      oauth_token_url: 'https://oidc.example.gov.bc.ca/token',
+      kong_admin_url: 'http://kong:8001',
+    },
+  })
+);
+process.env.ENVIRONMENTS_CONFIG_FILE = configPath;
+resetEnvironmentsCache();
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe('getRequiredEnvUrl', () => {
+  expect(
+    getRequiredEnvUrl('dev', 'operator_edge_url', 'SDX Operator edge server')
+  ).toBe(
+    'https://edge.dev.example.gov.bc.ca',
+    'returns the configured URL for the field'
+  );
+
+  let threw = false;
+  try {
+    getRequiredEnvUrl('test', 'operator_edge_url', 'SDX Operator edge server');
+  } catch (err) {
+    threw = true;
+    expect((err as Error).message).toBe(
+      "SDX Operator edge server is not configured for environment 'test'",
+      'error names the environment and description when the field is unconfigured'
+    );
+  }
+  expect(threw).toBe(
+    true,
+    'throws when the environment exists but lacks the field'
+  );
+
+  threw = false;
+  try {
+    getRequiredEnvUrl(undefined, 'public_url', 'SDX public URL');
+  } catch (err) {
+    threw = true;
+  }
+  expect(threw).toBe(
+    true,
+    'throws instead of looking up an undefined environment'
+  );
+
+  threw = false;
+  try {
+    getRequiredEnvUrl('missing-env', 'public_url', 'SDX public URL');
+  } catch (err) {
+    threw = true;
+  }
+  expect(threw).toBe(
+    true,
+    'throws when the environment is not in the config at all'
+  );
+});
+
+unlinkSync(configPath);
+resetEnvironmentsCache();
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}

--- a/provisioner-api/src/config/environments.ts
+++ b/provisioner-api/src/config/environments.ts
@@ -35,6 +35,14 @@ export type EnvironmentConfig = {
    * issuance. Each environment has its own step-ca instance.
    */
   ca_token_url?: string;
+  /**
+   * Public-facing base URL for this environment's SDX JWKS endpoints (e.g.
+   * `https://sdx.gov.bc.ca`), used to build the `jwks_uri` gateway plugin
+   * config peers use to verify signed requests/responses. Unlike
+   * `operator_edge_url`, this must be reachable by whichever party is
+   * verifying the signature, not just from the internal SDX network.
+   */
+  public_url?: string;
 };
 
 /** Map of environment name (`dev`, `test`, `prod`, `sbx`, …) to its config. */
@@ -115,6 +123,7 @@ function validate(parsed: unknown, path: string): EnvironmentsConfig {
     optionalString(entry, 'gwa_api_url', name, path);
     optionalString(entry, 'operator_edge_url', name, path);
     optionalString(entry, 'ca_token_url', name, path);
+    optionalString(entry, 'public_url', name, path);
     result[name] = {
       client_id: entry.client_id as string | undefined,
       oauth_token_url: entry.oauth_token_url as string,
@@ -122,6 +131,7 @@ function validate(parsed: unknown, path: string): EnvironmentsConfig {
       gwa_api_url: entry.gwa_api_url as string | undefined,
       operator_edge_url: entry.operator_edge_url as string | undefined,
       ca_token_url: entry.ca_token_url as string | undefined,
+      public_url: entry.public_url as string | undefined,
     };
   }
   return result;

--- a/provisioner-api/src/config/environments.ts
+++ b/provisioner-api/src/config/environments.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { InternalError, withDetails } from '../errors/api-errors.js';
 
 /**
  * Per-environment configuration. Sourced entirely from the external file named
@@ -102,6 +103,31 @@ export function resetEnvironmentsCache(): void {
   cached = undefined;
 }
 
+/**
+ * Looks up a required per-environment URL field (`operator_edge_url` or
+ * `public_url`), throwing a descriptive InternalError — this is a server-side
+ * misconfiguration, not an upstream/gateway failure — if `environment` is
+ * unspecified or the field isn't configured for it.
+ */
+export function getRequiredEnvUrl(
+  environment: string | undefined,
+  field: 'operator_edge_url' | 'public_url',
+  description: string
+): string {
+  const url = environment
+    ? loadEnvironments()[environment]?.[field]
+    : undefined;
+  if (!url) {
+    throw withDetails(
+      new InternalError(
+        `${description} is not configured for environment '${environment}'`
+      ),
+      { environment, missing: field }
+    );
+  }
+  return url;
+}
+
 function validate(parsed: unknown, path: string): EnvironmentsConfig {
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     throw new Error(
@@ -110,7 +136,9 @@ function validate(parsed: unknown, path: string): EnvironmentsConfig {
   }
 
   const result: EnvironmentsConfig = {};
-  for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+  for (const [name, value] of Object.entries(
+    parsed as Record<string, unknown>
+  )) {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       throw new Error(
         `ENVIRONMENTS_CONFIG_FILE (${path}): environment '${name}' must be an object`

--- a/provisioner-api/src/services/gateway-patterns/sdx-keys.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-keys.ts
@@ -4,8 +4,8 @@ import type { PatternProcessor } from '../patterns-evaluator.js';
 import { assert } from './utils.js';
 import { FastifyBaseLogger } from 'fastify/types/logger.js';
 import { OAuthClient } from '../../clients/oauth.js';
-
-const OPERATOR_CONSUMER_URL = process.env.SDX_OPERATOR_CONSUMER_URL!;
+import { loadEnvironments } from '../../config/environments.js';
+import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
 
 function splitCertificates(certs: string, encoding: BufferEncoding): string[] {
   const certArray = certs.split(/(?=-----BEGIN CERTIFICATE-----)/g);
@@ -188,7 +188,7 @@ export class SDXKeysPattern implements PatternProcessor {
     } as SDXKeysPatternData;
   }
 
-  eval(_: Record<string, string>, data: SDXKeysPatternData) {
+  eval(inputs: SDXKeyConfig, data: SDXKeysPatternData) {
     const profile = data.profile;
 
     let tags = [`ns.${data.gatewayId}.${profile.qualifier}`];
@@ -223,7 +223,17 @@ export class SDXKeysPattern implements PatternProcessor {
       });
     }
 
-    const routeHostUrl = new URL(OPERATOR_CONSUMER_URL);
+    const operatorEdgeUrl = loadEnvironments()[inputs.environment]
+      ?.operator_edge_url;
+    if (!operatorEdgeUrl) {
+      throw withDetails(
+        new BadGatewayError(
+          `SDX Operator edge server is not configured for environment '${inputs.environment}'`
+        ),
+        { environment: inputs.environment, missing: 'operator_edge_url' }
+      );
+    }
+    const routeHostUrl = new URL(operatorEdgeUrl);
 
     const info = {
       kind: 'Information',

--- a/provisioner-api/src/services/gateway-patterns/sdx-keys.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-keys.ts
@@ -4,8 +4,7 @@ import type { PatternProcessor } from '../patterns-evaluator.js';
 import { assert } from './utils.js';
 import { FastifyBaseLogger } from 'fastify/types/logger.js';
 import { OAuthClient } from '../../clients/oauth.js';
-import { loadEnvironments } from '../../config/environments.js';
-import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
+import { getRequiredEnvUrl } from '../../config/environments.js';
 
 function splitCertificates(certs: string, encoding: BufferEncoding): string[] {
   const certArray = certs.split(/(?=-----BEGIN CERTIFICATE-----)/g);
@@ -223,16 +222,11 @@ export class SDXKeysPattern implements PatternProcessor {
       });
     }
 
-    const operatorEdgeUrl = loadEnvironments()[inputs.environment]
-      ?.operator_edge_url;
-    if (!operatorEdgeUrl) {
-      throw withDetails(
-        new BadGatewayError(
-          `SDX Operator edge server is not configured for environment '${inputs.environment}'`
-        ),
-        { environment: inputs.environment, missing: 'operator_edge_url' }
-      );
-    }
+    const operatorEdgeUrl = getRequiredEnvUrl(
+      inputs.environment,
+      'operator_edge_url',
+      'SDX Operator edge server'
+    );
     const routeHostUrl = new URL(operatorEdgeUrl);
 
     const info = {

--- a/provisioner-api/src/services/gateway-patterns/sdx-p2p-consumer.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-p2p-consumer.ts
@@ -11,9 +11,8 @@ import {
   type EnrichedSubsystemEntry,
 } from './utils.js';
 import { Organization } from '../../clients/directory/index.js';
-
-// TODO: clean this up a bit!
-const SDX_PUBLIC_URL = process.env.SDX_PUBLIC_URL || 'http://sdx.public.url';
+import { loadEnvironments } from '../../config/environments.js';
+import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
 
 export interface SDXP2PConsumerPatternConfig {
   connId: string;
@@ -341,8 +340,19 @@ function upgradeToTrustSign(
   data: SDXP2PConsumerPatternData,
   inputs: SDXP2PConsumerPatternConfig
 ) {
-  const kid = `urn:ca:bc:sdx:edge:${data.clientRuntimeGroup.name}:${data.clientRuntimeGroup.environment}:0`;
-  const keySetName = `sdx.edge.${data.clientRuntimeGroup.name}.${data.clientRuntimeGroup.environment}`;
+  const environment = data.clientRuntimeGroup.environment!;
+  const kid = `urn:ca:bc:sdx:edge:${data.clientRuntimeGroup.name}:${environment}:0`;
+  const keySetName = `sdx.edge.${data.clientRuntimeGroup.name}.${environment}`;
+
+  const publicUrl = loadEnvironments()[environment]?.public_url;
+  if (!publicUrl) {
+    throw withDetails(
+      new BadGatewayError(
+        `SDX public URL is not configured for environment '${environment}'`
+      ),
+      { environment, missing: 'public_url' }
+    );
+  }
 
   return {
     name: 'trust-sign',
@@ -353,7 +363,7 @@ function upgradeToTrustSign(
       keyid: kid,
       private_key_location: '/etc/secrets/sdx-edge-signing-cert/tls.key',
       alg: inputs.upgrades.sign?.alg || 'ES256',
-      jwks_uri: `${SDX_PUBLIC_URL}/keysets/${keySetName}/.well-known/jwks.json`,
+      jwks_uri: `${publicUrl}/keysets/${keySetName}/.well-known/jwks.json`,
       hash_alg: 'sha256',
     },
   };

--- a/provisioner-api/src/services/gateway-patterns/sdx-p2p-consumer.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-p2p-consumer.ts
@@ -11,8 +11,7 @@ import {
   type EnrichedSubsystemEntry,
 } from './utils.js';
 import { Organization } from '../../clients/directory/index.js';
-import { loadEnvironments } from '../../config/environments.js';
-import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
+import { getRequiredEnvUrl } from '../../config/environments.js';
 
 export interface SDXP2PConsumerPatternConfig {
   connId: string;
@@ -340,19 +339,15 @@ function upgradeToTrustSign(
   data: SDXP2PConsumerPatternData,
   inputs: SDXP2PConsumerPatternConfig
 ) {
-  const environment = data.clientRuntimeGroup.environment!;
+  const environment = data.clientRuntimeGroup.environment;
   const kid = `urn:ca:bc:sdx:edge:${data.clientRuntimeGroup.name}:${environment}:0`;
   const keySetName = `sdx.edge.${data.clientRuntimeGroup.name}.${environment}`;
 
-  const publicUrl = loadEnvironments()[environment]?.public_url;
-  if (!publicUrl) {
-    throw withDetails(
-      new BadGatewayError(
-        `SDX public URL is not configured for environment '${environment}'`
-      ),
-      { environment, missing: 'public_url' }
-    );
-  }
+  const publicUrl = getRequiredEnvUrl(
+    environment,
+    'public_url',
+    'SDX public URL'
+  );
 
   return {
     name: 'trust-sign',

--- a/provisioner-api/src/services/gateway-patterns/sdx-p2p-provider.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-p2p-provider.ts
@@ -10,9 +10,8 @@ import {
   type EnrichedServiceCatalogEntry,
   type EnrichedSubsystemEntry,
 } from './utils.js';
-
-// TODO: clean this up a bit!
-const SDX_PUBLIC_URL = process.env.SDX_PUBLIC_URL || 'http://sdx.public.url';
+import { loadEnvironments } from '../../config/environments.js';
+import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
 
 export interface SDXP2PProviderPatternConfig extends Record<string, any> {
   connId: string;
@@ -301,8 +300,19 @@ function upgradeToTrustSign(
   data: SDXP2PProviderPatternData,
   inputs: SDXP2PProviderPatternConfig
 ) {
-  const kid = `urn:ca:bc:sdx:edge:${data.serviceRG.name}:${data.serviceRG.environment}:0`;
-  const keySetName = `sdx.edge.${data.serviceRG.name}.${data.serviceRG.environment}`;
+  const environment = data.serviceRG.environment!;
+  const kid = `urn:ca:bc:sdx:edge:${data.serviceRG.name}:${environment}:0`;
+  const keySetName = `sdx.edge.${data.serviceRG.name}.${environment}`;
+
+  const publicUrl = loadEnvironments()[environment]?.public_url;
+  if (!publicUrl) {
+    throw withDetails(
+      new BadGatewayError(
+        `SDX public URL is not configured for environment '${environment}'`
+      ),
+      { environment, missing: 'public_url' }
+    );
+  }
 
   return {
     name: 'trust-sign',
@@ -313,7 +323,7 @@ function upgradeToTrustSign(
       keyid: kid,
       private_key_location: '/etc/secrets/sdx-edge-signing-cert/tls.key',
       alg: inputs.upgrades.sign?.alg || 'ES256',
-      jwks_uri: `${SDX_PUBLIC_URL}/keysets/${keySetName}/.well-known/jwks.json`,
+      jwks_uri: `${publicUrl}/keysets/${keySetName}/.well-known/jwks.json`,
       hash_alg: 'sha256',
     },
   };

--- a/provisioner-api/src/services/gateway-patterns/sdx-p2p-provider.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-p2p-provider.ts
@@ -10,8 +10,7 @@ import {
   type EnrichedServiceCatalogEntry,
   type EnrichedSubsystemEntry,
 } from './utils.js';
-import { loadEnvironments } from '../../config/environments.js';
-import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
+import { getRequiredEnvUrl } from '../../config/environments.js';
 
 export interface SDXP2PProviderPatternConfig extends Record<string, any> {
   connId: string;
@@ -300,19 +299,15 @@ function upgradeToTrustSign(
   data: SDXP2PProviderPatternData,
   inputs: SDXP2PProviderPatternConfig
 ) {
-  const environment = data.serviceRG.environment!;
+  const environment = data.serviceRG.environment;
   const kid = `urn:ca:bc:sdx:edge:${data.serviceRG.name}:${environment}:0`;
   const keySetName = `sdx.edge.${data.serviceRG.name}.${environment}`;
 
-  const publicUrl = loadEnvironments()[environment]?.public_url;
-  if (!publicUrl) {
-    throw withDetails(
-      new BadGatewayError(
-        `SDX public URL is not configured for environment '${environment}'`
-      ),
-      { environment, missing: 'public_url' }
-    );
-  }
+  const publicUrl = getRequiredEnvUrl(
+    environment,
+    'public_url',
+    'SDX public URL'
+  );
 
   return {
     name: 'trust-sign',

--- a/provisioner-api/src/services/gateway-patterns/sdx-runtime-group.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-runtime-group.ts
@@ -3,8 +3,7 @@ import type { SdxMemberApiClient } from '../../clients/sdx-member/index.js';
 import type { RuntimeGroup } from '../../clients/sdx-member/index.js';
 import { PatternProcessor } from '../patterns-evaluator.js';
 import { assert } from './utils.js';
-import { loadEnvironments } from '../../config/environments.js';
-import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
+import { getRequiredEnvUrl } from '../../config/environments.js';
 
 export interface SDXRuntimeGroupPatternConfig {
   organization: string;
@@ -72,16 +71,11 @@ export class SDXRuntimeGroupPattern implements PatternProcessor {
     const consumerUrl = new URL(data.runtimeGroup.consumerEndpoint!);
     const consumerHost = consumerUrl.hostname;
 
-    const operatorEdgeUrl = loadEnvironments()[inputs.environment]
-      ?.operator_edge_url;
-    if (!operatorEdgeUrl) {
-      throw withDetails(
-        new BadGatewayError(
-          `SDX Operator edge server is not configured for environment '${inputs.environment}'`
-        ),
-        { environment: inputs.environment, missing: 'operator_edge_url' }
-      );
-    }
+    const operatorEdgeUrl = getRequiredEnvUrl(
+      inputs.environment,
+      'operator_edge_url',
+      'SDX Operator edge server'
+    );
     const routeHostUrl = new URL(operatorEdgeUrl);
 
     let tags = [`ns.${gw}.${nsQualifier}`, 'sdx'];

--- a/provisioner-api/src/services/gateway-patterns/sdx-runtime-group.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-runtime-group.ts
@@ -3,8 +3,8 @@ import type { SdxMemberApiClient } from '../../clients/sdx-member/index.js';
 import type { RuntimeGroup } from '../../clients/sdx-member/index.js';
 import { PatternProcessor } from '../patterns-evaluator.js';
 import { assert } from './utils.js';
-
-const OPERATOR_CONSUMER_URL = process.env.SDX_OPERATOR_CONSUMER_URL!;
+import { loadEnvironments } from '../../config/environments.js';
+import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
 
 export interface SDXRuntimeGroupPatternConfig {
   organization: string;
@@ -72,7 +72,17 @@ export class SDXRuntimeGroupPattern implements PatternProcessor {
     const consumerUrl = new URL(data.runtimeGroup.consumerEndpoint!);
     const consumerHost = consumerUrl.hostname;
 
-    const routeHostUrl = new URL(OPERATOR_CONSUMER_URL);
+    const operatorEdgeUrl = loadEnvironments()[inputs.environment]
+      ?.operator_edge_url;
+    if (!operatorEdgeUrl) {
+      throw withDetails(
+        new BadGatewayError(
+          `SDX Operator edge server is not configured for environment '${inputs.environment}'`
+        ),
+        { environment: inputs.environment, missing: 'operator_edge_url' }
+      );
+    }
+    const routeHostUrl = new URL(operatorEdgeUrl);
 
     let tags = [`ns.${gw}.${nsQualifier}`, 'sdx'];
 

--- a/provisioner-api/src/services/gateway-patterns/sdx-service.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-service.ts
@@ -7,8 +7,8 @@ import type {
 import { convertPath } from '../kong/openapi-to-kong/openapi-to-kong-paths.js';
 import { PatternProcessor } from '../patterns-evaluator.js';
 import { assert, type EnrichedServiceCatalogEntry } from './utils.js';
-
-const SDX_PUBLIC_URL = process.env.SDX_PUBLIC_URL || 'https://sdx.gov.bc.ca';
+import { loadEnvironments } from '../../config/environments.js';
+import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
 
 export interface SDXServiceConfig {
   serviceId: string;
@@ -284,6 +284,17 @@ function upgradeToACL(tags: string[], data: SDXServicePatternData) {
 function upgradeToTrustSign(tags: string[], data: SDXServicePatternData) {
   const kid = `urn:ca:bc:sdx:edge:${data.subsystemRuntimeGroup.name!}:0`;
   const keySetName = `sdx.edge.${data.subsystemRuntimeGroup.name!}`;
+  const environment = data.subsystemRuntimeGroup.environment!;
+
+  const publicUrl = loadEnvironments()[environment]?.public_url;
+  if (!publicUrl) {
+    throw withDetails(
+      new BadGatewayError(
+        `SDX public URL is not configured for environment '${environment}'`
+      ),
+      { environment, missing: 'public_url' }
+    );
+  }
 
   return {
     name: 'trust-sign',
@@ -294,7 +305,7 @@ function upgradeToTrustSign(tags: string[], data: SDXServicePatternData) {
       keyid: kid,
       private_key_location: '/etc/secrets/sdx-edge-signing-cert/tls.key',
       alg: 'ES256',
-      jwks_uri: `${SDX_PUBLIC_URL}/keysets/${keySetName}/.well-known/jwks.json`,
+      jwks_uri: `${publicUrl}/keysets/${keySetName}/.well-known/jwks.json`,
       hash_alg: 'sha256',
     },
   };

--- a/provisioner-api/src/services/gateway-patterns/sdx-service.ts
+++ b/provisioner-api/src/services/gateway-patterns/sdx-service.ts
@@ -7,8 +7,7 @@ import type {
 import { convertPath } from '../kong/openapi-to-kong/openapi-to-kong-paths.js';
 import { PatternProcessor } from '../patterns-evaluator.js';
 import { assert, type EnrichedServiceCatalogEntry } from './utils.js';
-import { loadEnvironments } from '../../config/environments.js';
-import { BadGatewayError, withDetails } from '../../errors/api-errors.js';
+import { getRequiredEnvUrl } from '../../config/environments.js';
 
 export interface SDXServiceConfig {
   serviceId: string;
@@ -284,17 +283,13 @@ function upgradeToACL(tags: string[], data: SDXServicePatternData) {
 function upgradeToTrustSign(tags: string[], data: SDXServicePatternData) {
   const kid = `urn:ca:bc:sdx:edge:${data.subsystemRuntimeGroup.name!}:0`;
   const keySetName = `sdx.edge.${data.subsystemRuntimeGroup.name!}`;
-  const environment = data.subsystemRuntimeGroup.environment!;
+  const environment = data.subsystemRuntimeGroup.environment;
 
-  const publicUrl = loadEnvironments()[environment]?.public_url;
-  if (!publicUrl) {
-    throw withDetails(
-      new BadGatewayError(
-        `SDX public URL is not configured for environment '${environment}'`
-      ),
-      { environment, missing: 'public_url' }
-    );
-  }
+  const publicUrl = getRequiredEnvUrl(
+    environment,
+    'public_url',
+    'SDX public URL'
+  );
 
   return {
     name: 'trust-sign',

--- a/provisioner-api/src/services/policies/SDX.R0.00/schema.cedarschema
+++ b/provisioner-api/src/services/policies/SDX.R0.00/schema.cedarschema
@@ -102,7 +102,8 @@ namespace SDX {
                         kong_admin_url: String,
                         gwa_api_url: String,
                         operator_edge_url: String,
-                        ca_token_url: String
+                        ca_token_url: String,
+                        public_url: String
                     }
                 }
             },

--- a/provisioner-api/src/services/policies/SDX.R1.00/schema.cedarschema
+++ b/provisioner-api/src/services/policies/SDX.R1.00/schema.cedarschema
@@ -64,7 +64,8 @@ namespace SDX {
                         kong_admin_url: String,
                         gwa_api_url: String,
                         operator_edge_url: String,
-                        ca_token_url: String
+                        ca_token_url: String,
+                        public_url: String
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Two SDX Operator integrations read a single global env var instead of the per-environment config that every other integration (CSR generation, CA tokens) already uses (`operator_edge_url`/`ca_token_url` in `ENVIRONMENTS_CONFIG_FILE`).

**`SDX_OPERATOR_CONSUMER_URL`** (`sdx-runtime-group.r1`'s KMS route, `sdx-keys.r1`'s JWKS info endpoint):
- Swapped for `loadEnvironments()[environment]?.operator_edge_url`, throwing `BadGatewayError` when unconfigured (matches `SdxOperatorApiClient`'s existing missing-config handling).
- `sdx-keys.ts`'s `eval()` previously discarded its first argument as `_: Record<string, string>`; retyped to `SDXKeyConfig` to access `environment`.
- Removed the now-dead `SDX_OPERATOR_CONSUMER_URL` from all three env files.

**`SDX_PUBLIC_URL`** (`sdx-service.r1`, `sdx-p2p-provider.r1`, `sdx-p2p-consumer.r1`'s `trust-sign` plugin `jwks_uri`):
- Added a new `public_url` field to `EnvironmentsConfig`/`environments.json`, kept distinct from `operator_edge_url` since it must be reachable by whichever peer gateway verifies the signature, not just from the internal SDX network (the two vars have different fallback defaults in code even though they coincide in local dev).
- Mirrored into both `SDX.R0.00`/`SDX.R1.00` cedarschema files alongside the other environment config fields already exposed to policy evaluation.
- Swapped the three module-level constants for the same `loadEnvironments()[environment]?.public_url` + `BadGatewayError` pattern.
- Removed the now-dead `SDX_PUBLIC_URL` from the two `.env.local` files.

## Test plan
- [x] `provisioner-api` typecheck (`npm run typecheck`) passes.
- [x] `21-sdx-api/v1/08-catalog-activity.ts` — 14/14, exercises `sdx-keys.r1` apply/delete.
- [x] `21-sdx-api/v1/09-e2e-tests.ts` — 2/2, full connection provisioning between two subsystems; provisioner logs confirm `jwks_uri` now resolves from `public_url` for both `sdx-p2p-consumer.r1` and `sdx-p2p-provider.r1`.
- [x] Manually verified `sdx-runtime-group.r1` apply (no existing e2e coverage for this specific pattern) via a throwaway test — provisioner logs confirmed `operator_edge_url` resolved correctly and the KMS route was created successfully.
- [x] `/code-review` (medium effort) on both commits — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
